### PR TITLE
feat: role-based dashboards for full company hierarchy (8 roles, 7 dashboards)

### DIFF
--- a/plans/01-role-dashboards.md
+++ b/plans/01-role-dashboards.md
@@ -1,0 +1,199 @@
+# Afridrop Role-Based Dashboards — Implementation Plan
+
+**Goal:** Every staff role owns its own dashboard, sees only what its role permits, per the company hierarchy: Super Admin > Director > Manager > (Sales Manager / Accountant / Receptionist) > Technicians. Customers keep `/portal`.
+
+**Delivery model (user-approved):** Phased. This plan = role foundation + all 7 dashboards wired to data that **exists today**. Missing business modules (invoices, leads pipeline, appointments, time-logs, payroll, full approvals engine) ship as separate later plans; their dashboard sections render clean "Module coming" cards for now.
+
+**Flowstep reference design:** Super Admin dashboard — fileId `f219ca84-1065-42d6-924b-ccae6c269d68`, screenId `fa6bef2e-3190-4ca7-9885-f28e8851c78c` (use `mcp__flowstep__get-screen-image` / `get-screen` to view layout + JSX).
+
+---
+
+## Locked Decisions (from owner, 2026-06-10)
+
+1. **Final roles (8):** `super_admin`, `director`, `manager`, `sales_manager`, `accountant`, `receptionist`, `technician`, `customer`.
+2. **Old roles:** `attendant` → renamed `technician` (data migration). Generic `admin` role **removed from code**; existing admin users get reassigned manually by Super Admin via the Users page.
+3. **Director approvals** (later approvals module; Phase 3 starts with quotation approval only, since `quotations.status` already supports it): all quotations, expenses & payments, new staff accounts, purchases, project contracts, client onboarding.
+4. **Finance depth:** invoices + expenses first (later plan); payroll deferred; "Payroll — coming soon" card.
+5. **Job dispatch:** Manager assigns technicians (unchanged). Receptionist will only *book* appointments (later module) feeding the Manager's queue.
+6. **Technician UX:** mobile-first task list + big status buttons + client contact. Map routing later.
+7. **Leads:** extend `clients` table later (pipelineStage, source, estimatedValue, salesOwnerId) — NOT a separate leads table.
+8. **Accounts:** migrate existing users only; Super Admin creates new staff accounts himself.
+
+## Access Matrix (enforce in every phase)
+
+| Role | Owns (create/edit) | Views read-only | Never sees |
+|---|---|---|---|
+| super_admin | settings, users, roles | everything, audit logs | — |
+| director | approvals (quotations now) | all company data, revenue, staff metrics | system settings/users CRUD |
+| manager | job assignment, client status, staff messages | team schedules, dept metrics | super-admin settings |
+| sales_manager | leads (clients w/ status=lead), quotations | overall revenue | salaries, settings, audit logs |
+| accountant | (invoices/expenses later) payments view | job statuses, client list | settings, sales pipeline detail |
+| receptionist | (appointments later) basic client contact info | technician availability, contact lists | ALL financials, employee data |
+| technician | own job status updates | own assigned jobs, basic client contact | ALL financials (incl. quotation amounts), other techs' jobs |
+
+---
+
+## Phase 0 — Discovery Findings (consolidated; verified 2026-06-10)
+
+**Stack:** Next.js 16.1.6, better-auth 1.6.15 (admin plugin), Drizzle/Postgres (Neon), Tailwind v4 + shadcn/ui, lucide-react.
+
+**Allowed APIs / patterns (copy these, do not invent):**
+- Role list: `src/lib/permissions.ts:18-26` — currently `super_admin, admin, manager, attendant, customer`.
+- Auth config: `src/lib/auth.ts` — `adminRoles: ["admin","super_admin"]` at lines 52 & 68; default role `customer` line 51.
+- Post-login routing: `homeForRole()` in `src/lib/roles.ts:1-17`.
+- Session-cookie middleware: `src/proxy.ts` (named `proxy` export, Next 16) — cookie presence check only; matcher `["/admin/:path*","/portal/:path*","/manager/:path*","/attendant/:path*","/auth/:path*"]`. Real role checks live in layouts.
+- Layout role-guard pattern (COPY THIS): `src/app/manager/layout.tsx:14-22` — `getSession()` → check `session.user.role` → `redirect(homeForRole(role))`.
+- Role-scoped data layer (COPY THIS): `src/lib/work.ts` — `roleOf()`, `scopedCustomerIds()` (null = unrestricted, array = manager scope via `clients.assignedManagerId`), `getJobs(scope)`, `getThreads(scope)`, `getActiveAttendants()`.
+- Guarded mutations (COPY THIS): `src/lib/work-actions.ts` — `requireRole(WORK_ROLES)` + `assertJobInScope()` before every write.
+- Role-specific page data: `src/app/manager/actions.ts` — `requireRole(['manager'])` per function.
+- Dashboard nav component: `src/components/dashboard/ManagerNav.tsx` (sticky tabs). Admin sidebar: `src/app/admin/layout.tsx`.
+- Jobs = `quotations` table (`src/db/schema/quotations.ts`), status lifecycle in `src/lib/work.ts:9-20`: `pending, assigned, in_progress, completed, verified, cancelled`; quotation approval statuses: `pending, reviewed, approved, rejected, converted`.
+- Existing tables: users/sessions/accounts/verifications, clients (has `assignedManagerId`, `latitude/longitude`, `status: lead|active|inactive`), quotations(+items), orders(+items, cartItems), products(+categories/images/variants), messages, blog*, projects*, payments, inventoryStock/Transactions, **auditLogs** (`src/db/schema/payments.ts`).
+- **Tables that DO NOT exist** (do not query, do not invent): invoices, payroll, expenses, leads, visitorLogs, appointments, timeLogs.
+
+**Anti-patterns (global):**
+- ❌ Never rely on `proxy.ts` for role auth — it only checks cookie existence. Every dashboard needs layout guard + `requireRole` in its data layer.
+- ❌ Never select `quotations.totalAmount`/`estimatedBudget` or `payments` columns in receptionist/technician queries.
+- ❌ No better-auth `accessControl` statements — project uses plain role strings + `requireRole`; keep that pattern.
+- ❌ Don't scaffold pages for data that doesn't exist; render a shared `<ComingSoon module="..." />` card instead.
+- UI work: invoke `ui-ux-pro-max` skill before building screens; brand colors `#009FCE` / `#00477A`; follow manager layout conventions.
+
+---
+
+## Phase 1 — Role Foundation & Migration
+
+**Implement:**
+1. `src/lib/permissions.ts`: replace role list with the 8 final roles (remove `admin`, `attendant`; add `director`, `sales_manager`, `accountant`, `receptionist`, `technician`).
+2. `src/lib/auth.ts`: `adminRoles: ["super_admin"]` (both occurrences, lines ~52/68). Default role stays `customer`.
+3. `src/lib/roles.ts` `homeForRole`: `customer→/portal`, `technician→/technician`, `manager→/manager`, `sales_manager→/sales`, `accountant→/accounts`, `receptionist→/reception`, `director→/director`, `super_admin→/admin`, default `/`.
+4. `src/proxy.ts`: matcher + protected-prefix check → add `/director`, `/sales`, `/accounts`, `/reception`, `/technician`; remove `/attendant`.
+5. Data migration (Drizzle migration or one-off SQL): `UPDATE users SET role='technician' WHERE role='attendant';`. Leave `admin` rows untouched — they land on `/` until Super Admin reassigns them (note this in PR description).
+6. Rename route dir `src/app/attendant` → `src/app/technician`; update its layout guard to `role === 'technician'` (copy guard pattern from manager layout).
+7. Scaffold stub route groups so `homeForRole` never 404s: `src/app/director`, `src/app/sales`, `src/app/accounts`, `src/app/reception` — each with layout (role guard, copy `src/app/manager/layout.tsx:14-22`) + minimal page ("dashboard coming in next phase").
+8. `src/lib/work.ts`: update `Role` type; rename `getActiveAttendants` → `getActiveTechnicians` (query `role='technician'`); fix all call sites (`src/app/manager/actions.ts`, manager pages, `work-actions.ts`).
+9. `src/app/admin/users/page.tsx`: assignable roles → `['director','manager','sales_manager','accountant','receptionist','technician','customer']` (super_admin still not assignable via UI).
+10. Shared `src/components/dashboard/ComingSoon.tsx` card component (used by later phases).
+
+**Verify:**
+- `npm run build` passes (catches every stale `attendant`/`admin` role reference).
+- `grep -rn "'attendant'" src/` → zero hits. `grep -rn "'admin'" src/lib src/app` → only legit better-auth plugin strings, no role comparisons.
+- Login as each existing user type → lands on correct home; manager dashboard still works (regression).
+- Direct URL to another role's dashboard redirects away (test technician → `/manager`).
+
+**Anti-pattern guards:** don't add an `admin` fallback case in `homeForRole`; don't drop the route-rename migration for attendants; don't touch portal/customer flows.
+
+---
+
+## Phase 2 — Super Admin Dashboard (Flowstep design)
+
+**Implement** (layout per Flowstep screen `fa6bef2e…` — fetch image/JSX for reference):
+1. Restructure `src/app/admin/layout.tsx` sidebar: top group **Overview, Users & Roles (/admin/users), Audit Logs (/admin/audit), System Settings (/admin/settings)**; collapsible **All Data** group (Clients, Jobs, Orders, Products, Projects, Blog, Messages — existing pages unchanged). Header: role badge "Super Admin", sign out.
+2. Rebuild `src/app/admin/page.tsx` overview as system-health view: cards (active users count, live sessions from `sessions` table, failed logins — see note, DB status), "Users by Role" bar chart (count users grouped by role; simple CSS/SVG bars, no chart lib unless one already installed), Quick Actions (Create User → /admin/users, Reset Password, Manage Roles), Recent Audit Logs table (from `auditLogs`).
+3. New `src/app/admin/audit/page.tsx`: paginated `auditLogs` table (user, action, resource, time). super_admin-only data layer (`requireRole(['super_admin'])`).
+4. **Failed logins note:** auth failures are not currently written to `auditLogs`. If trivial, add a better-auth hook/log on failed sign-in writing to `auditLogs`; otherwise omit the card — do NOT fake the number.
+5. Restrict `/admin` layout guard to `super_admin` only (was admin|super_admin; `admin` role is gone).
+
+**Verify:** build passes; super_admin sees new overview + audit page; users-by-role chart matches `SELECT role, count(*) FROM users GROUP BY role`; non-super_admin redirected from `/admin/*`.
+
+**Anti-pattern guards:** no invented metrics (uptime/storage from the mock are decorative — skip unless real source); no new chart dependency without checking package.json first.
+
+---
+
+## Phase 3 — Director Dashboard (`/director`)
+
+Macro view, read-everything, owns approvals. No daily task lists.
+
+**Implement:**
+1. `src/app/director/actions.ts` data layer, every fn `requireRole(['director','super_admin'])`:
+   - `getCompanyOverview()`: total revenue (sum `payments` where status='completed'), revenue by month (last 6), active jobs count by status (quotations), orders count, clients by status.
+   - `getDepartmentPerformance()`: jobs completed per technician/manager, quotation conversion (approved+converted vs total), sales (orders/mo).
+   - `getPendingApprovals()`: quotations with status `pending`/`reviewed` (the only approval type that exists today).
+2. `src/app/director/approvals-actions.ts`: `approveQuotation(id)` / `rejectQuotation(id)` server actions — `requireRole(['director','super_admin'])`, update `quotations.status`. Write an `auditLogs` row per decision.
+3. Pages: `/director` (overview: revenue chart, active projects, dept performance cards), `/director/approvals` (pending quotations w/ approve/reject), `/director/reports` (staff metrics read-only). Nav via a `DirectorNav` copied from `ManagerNav.tsx` pattern.
+4. ComingSoon cards: "Expense approvals", "Contract approvals", "Client onboarding approvals" (approvals engine = later plan).
+
+**Verify:** director login → `/director`; approving a quotation changes status + audit row exists; director CANNOT reach `/admin/users` or `/admin/settings` (redirect); revenue figure matches manual SQL sum.
+
+**Anti-pattern guards:** director gets NO edit access to users/settings; don't build the generic approvals table yet — quotation status only.
+
+---
+
+## Phase 4 — Technician Dashboard (`/technician`, mobile-first)
+
+**Implement:**
+1. `src/app/technician/actions.ts` — `requireRole(['technician'])`:
+   - `getMyJobs()`: quotations where `assignedTo = session.user.id`, statuses `assigned|in_progress`, ordered by date — select ONLY: id, quotationNumber, customerName, location, projectDescription, status, client phone/address (join clients by customerId where available). **Exclude all money columns.**
+   - `updateMyJobStatus(jobId, status)`: allowed transitions only `assigned→in_progress→completed`; verify `assignedTo === session.user.id` before update (copy `assertJobInScope` shape from `work-actions.ts`).
+2. Page `/technician`: mobile-first single column — "My Tasks for Today" cards: client name, phone (tel: link), address, job description, big full-width status button (Start Job / Mark Complete), status badge. Completed-today section below. ComingSoon: "Map navigation", "Time logs & field notes".
+3. Layout: lightweight header (no sidebar), `role === 'technician'` guard.
+4. Manager terminology sweep: team page / JobsBoard / TeamGrid labels "Attendant" → "Technician".
+
+**Verify:** technician sees only own jobs (create 2 technicians, cross-check); `grep -n "totalAmount\|estimatedBudget" src/app/technician/` → zero hits; status button transitions persist and reflect on manager's JobsBoard; page usable at 375px width.
+
+**Anti-pattern guards:** no financial fields in any technician query/component; no other technicians' schedules; no desktop-style sidebar.
+
+---
+
+## Phase 5 — Sales Manager Dashboard (`/sales`)
+
+**Implement:**
+1. `src/app/sales/actions.ts` — `requireRole(['sales_manager','super_admin'])`:
+   - `getLeads()`: clients where status='lead' (full edit on these); `updateLeadStatus()` mutation (lead→active = "won").
+   - `getQuotationPipeline()`: quotations grouped by status (pending/reviewed/approved/rejected/converted) — this IS the pipeline until leads module lands.
+   - `getRevenueReadonly()`: monthly totals from completed payments — display-only.
+2. Pages: `/sales` (pipeline columns by quotation status + conversion rate + revenue card), `/sales/leads` (lead list w/ status edit), ComingSoon: "Pipeline stages & lead sources" (clients-table extension, later plan).
+
+**Verify:** sales_manager login → `/sales`; can edit lead status, cannot reach `/admin`, `/director`, `/accounts`; `grep` confirms no users-table salary-ish or audit-log queries in `src/app/sales/`.
+
+**Anti-pattern guards:** read-only revenue (no payment mutations); no separate leads table.
+
+---
+
+## Phase 6 — Accountant Dashboard (`/accounts`)
+
+**Implement:**
+1. `src/app/accounts/actions.ts` — `requireRole(['accountant','super_admin'])`:
+   - `getPayments()`: payments table w/ order + customer join (table-driven, filter by status/method).
+   - `getReceivables()`: orders where paymentStatus='pending' + approved/converted quotations totals.
+   - `getJobStatusesReadonly()` and `getClientListReadonly()` (names/contacts, no edit).
+2. Pages: `/accounts` (cash-position cards: collected this month, pending, by payment method + payments table), `/accounts/payments` (full filterable table). ComingSoon: "Invoices", "Expenses", "Payroll" (next finance plan).
+
+**Verify:** accountant login → `/accounts`; payment totals match SQL; cannot reach `/admin/settings` or `/sales` (redirects); read-only — no mutation actions exported.
+
+**Anti-pattern guards:** no invoices/expenses/payroll tables; no settings or pipeline access.
+
+---
+
+## Phase 7 — Receptionist Dashboard (`/reception`)
+
+**Implement:**
+1. `src/app/reception/actions.ts` — `requireRole(['receptionist','super_admin'])`:
+   - `getContactList()`: clients — name, phone, email, address, status ONLY (no pool budget/financial joins). `updateClientContact()` for basic contact-info edits.
+   - `getTechnicianAvailability()`: technicians + count of active jobs each (reuse `getActiveTechnicians` + jobs count; NO job financial detail).
+   - `getRecentInquiries()`: latest inbound `messages` rows.
+2. Pages: `/reception` (today panel: technician availability grid, recent inquiries, quick contact search), `/reception/contacts` (client directory). ComingSoon: "Appointments calendar", "Visitor log", "Call log" (appointments plan; bookings will feed Manager queue per decision #5).
+
+**Verify:** receptionist login → `/reception`; `grep -n "payments\|totalAmount\|orders" src/app/reception/` → zero hits; cannot reach any other dashboard.
+
+**Anti-pattern guards:** zero financial data; no employee personal data beyond name + active-job count; receptionist does NOT assign technicians.
+
+---
+
+## Phase 8 — Final Verification (whole plan)
+
+1. `npm run build` clean.
+2. Role-matrix walk: log in as one user per role (create test users via `/admin/users`) → correct home, correct nav, every cross-role URL redirects.
+3. Greps: `grep -rn "'attendant'\|role === 'admin'" src/` → 0; `grep -rn "totalAmount" src/app/technician src/app/reception` → 0.
+4. Data spot-checks: director revenue vs SQL; technician job isolation between two technician accounts; manager scope regression (`assignedManagerId`).
+5. Confirm `auditLogs` rows written for quotation approvals and user-management actions.
+6. Deploy preview → repeat role-matrix walk on Vercel preview before production.
+
+---
+
+## Later Plans (out of scope here, in priority order)
+1. **Approvals engine** — generic approvals table (expenses, payments, purchases, contracts, staff accounts, client onboarding) + Director inbox.
+2. **Invoices + expenses** module (Accountant). Payroll after.
+3. **Appointments + visitor/call log** (Receptionist books → Manager assigns).
+4. **Leads pipeline** — extend clients (pipelineStage, source, estimatedValue, salesOwnerId) + Sales kanban.
+5. **Technician field tools** — map deep-links (lat/long exists), time-logs, field notes.
+6. Flowstep designs for remaining 6 dashboards (same file `f219ca84…`, one screen per role) before each UI phase.

--- a/scripts/migrate-roles.sql
+++ b/scripts/migrate-roles.sql
@@ -1,0 +1,8 @@
+-- Role migration: attendant → technician
+-- Run this once against the production database after deploying the
+-- feature/role-dashboards branch. It is safe to run on an already-migrated
+-- database (WHERE clause silently matches zero rows).
+--
+--   psql $DATABASE_URL -f scripts/migrate-roles.sql
+--
+UPDATE users SET role = 'technician' WHERE role = 'attendant';

--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -1,0 +1,225 @@
+'use server';
+
+import { db } from '@/db';
+import { payments } from '@/db/schema/payments';
+import { orders } from '@/db/schema/orders';
+import { quotations } from '@/db/schema/quotations';
+import { users } from '@/db/schema/auth';
+import { count, eq, inArray, isNull, sum, and, desc, gte, lt, sql } from 'drizzle-orm';
+import { requireRole } from '@/lib/auth';
+
+const PAGE_SIZE = 25;
+
+// First-of-current-month midnight in Africa/Kampala (EAT, UTC+3).
+function eatMonthStart(): Date {
+  const nowEAT = new Intl.DateTimeFormat('en-CA', { timeZone: 'Africa/Kampala' }).format(new Date());
+  // nowEAT is "YYYY-MM-DD"; replace day with "01"
+  const [year, month] = nowEAT.split('-');
+  return new Date(`${year}-${month}-01T00:00:00+03:00`);
+}
+
+// ── Cash Position ─────────────────────────────────────────────────────────
+export async function getCashPosition() {
+  await requireRole(['accountant', 'super_admin']);
+
+  const monthStart = eatMonthStart();
+
+  const [
+    collectedThisMonthRow,
+    collectedAllTimeRow,
+    pendingRow,
+    byMethodRows,
+    monthlyRows,
+  ] = await Promise.all([
+    // Collected this month (completed payments since EAT month start)
+    db
+      .select({ total: sum(payments.amount) })
+      .from(payments)
+      .where(and(eq(payments.status, 'completed'), gte(payments.createdAt, monthStart)))
+      .then((rows) => rows[0]),
+
+    // All-time collected
+    db
+      .select({ total: sum(payments.amount) })
+      .from(payments)
+      .where(eq(payments.status, 'completed'))
+      .then((rows) => rows[0]),
+
+    // Pending payments: sum + count
+    db
+      .select({ total: sum(payments.amount), qty: count() })
+      .from(payments)
+      .where(eq(payments.status, 'pending'))
+      .then((rows) => rows[0]),
+
+    // Breakdown by payment method (completed only)
+    db
+      .select({ method: payments.paymentMethod, total: sum(payments.amount) })
+      .from(payments)
+      .where(eq(payments.status, 'completed'))
+      .groupBy(payments.paymentMethod),
+
+    // Monthly collected last 6 months
+    db
+      .select({
+        month: sql<string>`to_char(${payments.createdAt}, 'Mon YYYY')`,
+        monthSort: sql<string>`to_char(${payments.createdAt}, 'YYYY-MM')`,
+        total: sum(payments.amount),
+      })
+      .from(payments)
+      .where(
+        and(
+          eq(payments.status, 'completed'),
+          gte(
+            payments.createdAt,
+            (() => {
+              const d = new Date();
+              d.setMonth(d.getMonth() - 5);
+              d.setDate(1);
+              d.setHours(0, 0, 0, 0);
+              return d;
+            })(),
+          ),
+        ),
+      )
+      .groupBy(
+        sql`to_char(${payments.createdAt}, 'Mon YYYY')`,
+        sql`to_char(${payments.createdAt}, 'YYYY-MM')`,
+      )
+      .orderBy(sql`to_char(${payments.createdAt}, 'YYYY-MM')`),
+  ]);
+
+  return {
+    collectedThisMonth: Number(collectedThisMonthRow?.total ?? 0),
+    collectedAllTime: Number(collectedAllTimeRow?.total ?? 0),
+    pendingTotal: Number(pendingRow?.total ?? 0),
+    pendingCount: Number(pendingRow?.qty ?? 0),
+    byMethod: byMethodRows.map((r) => ({
+      method: r.method,
+      total: Number(r.total ?? 0),
+    })),
+    monthlyCollected: monthlyRows.map((r) => ({
+      month: r.month,
+      total: Number(r.total ?? 0),
+    })),
+  };
+}
+
+// ── Payments (paginated) ──────────────────────────────────────────────────
+export async function getPayments(page: number) {
+  await requireRole(['accountant', 'super_admin']);
+
+  const safePage = Math.max(1, page);
+  const offset = (safePage - 1) * PAGE_SIZE;
+
+  const [countRow, rows] = await Promise.all([
+    db.select({ value: count() }).from(payments).then((r) => r[0]),
+    db
+      .select({
+        id: payments.id,
+        amount: payments.amount,
+        status: payments.status,
+        paymentMethod: payments.paymentMethod,
+        transactionId: payments.transactionId,
+        createdAt: payments.createdAt,
+        // Customer via payments.userId → users
+        customerName: users.name,
+        customerEmail: users.email,
+        // Order reference
+        orderNumber: orders.orderNumber,
+      })
+      .from(payments)
+      .leftJoin(users, eq(payments.userId, users.id))
+      .leftJoin(orders, eq(payments.orderId, orders.id))
+      .orderBy(desc(payments.createdAt))
+      .limit(PAGE_SIZE)
+      .offset(offset),
+  ]);
+
+  return {
+    total: Number(countRow.value),
+    totalPages: Math.max(1, Math.ceil(Number(countRow.value) / PAGE_SIZE)),
+    page: safePage,
+    rows: rows.map((r) => ({
+      ...r,
+      amount: Number(r.amount),
+    })),
+  };
+}
+
+// ── Receivables ───────────────────────────────────────────────────────────
+export async function getReceivables() {
+  await requireRole(['accountant', 'super_admin']);
+
+  const [pendingOrders, receivableQuotations] = await Promise.all([
+    // Orders where payment is still pending
+    db
+      .select({
+        id: orders.id,
+        orderNumber: orders.orderNumber,
+        customerName: orders.customerName,
+        customerEmail: orders.customerEmail,
+        total: orders.total,
+        createdAt: orders.createdAt,
+      })
+      .from(orders)
+      .where(and(isNull(orders.deletedAt), eq(orders.paymentStatus, 'pending')))
+      .orderBy(desc(orders.createdAt)),
+
+    // Approved / converted quotations as receivable candidates
+    db
+      .select({
+        id: quotations.id,
+        quotationNumber: quotations.quotationNumber,
+        customerName: quotations.customerName,
+        customerEmail: quotations.customerEmail,
+        totalAmount: quotations.totalAmount,
+        status: quotations.status,
+        createdAt: quotations.createdAt,
+      })
+      .from(quotations)
+      .where(
+        and(
+          isNull(quotations.deletedAt),
+          inArray(quotations.status as any, ['approved', 'converted']),
+        ),
+      )
+      .orderBy(desc(quotations.createdAt)),
+  ]);
+
+  return {
+    pendingOrders: pendingOrders.map((r) => ({
+      ...r,
+      total: Number(r.total),
+    })),
+    receivableQuotations: receivableQuotations.map((r) => ({
+      ...r,
+      totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
+    })),
+  };
+}
+
+// ── Job Status Summary ────────────────────────────────────────────────────
+export async function getJobStatusSummary() {
+  await requireRole(['accountant', 'super_admin']);
+
+  const JOB_STATUSES = ['assigned', 'in_progress', 'completed', 'verified'] as const;
+
+  const rows = await db
+    .select({ status: quotations.status, value: count() })
+    .from(quotations)
+    .where(
+      and(
+        isNull(quotations.deletedAt),
+        inArray(quotations.status as any, [...JOB_STATUSES]),
+      ),
+    )
+    .groupBy(quotations.status);
+
+  const byStatus: Record<string, number> = {};
+  for (const r of rows) {
+    byStatus[r.status ?? ''] = Number(r.value);
+  }
+
+  return JOB_STATUSES.map((s) => ({ status: s, count: byStatus[s] ?? 0 }));
+}

--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -5,7 +5,8 @@ import { payments } from '@/db/schema/payments';
 import { orders } from '@/db/schema/orders';
 import { quotations } from '@/db/schema/quotations';
 import { users } from '@/db/schema/auth';
-import { count, eq, inArray, isNull, sum, and, desc, gte, lt, sql } from 'drizzle-orm';
+import { clients } from '@/db/schema/clients';
+import { count, eq, inArray, isNull, sum, and, desc, gte, sql } from 'drizzle-orm';
 import { requireRole } from '@/lib/auth';
 
 const PAGE_SIZE = 25;
@@ -105,40 +106,64 @@ export async function getCashPosition() {
   };
 }
 
+const VALID_STATUSES = ['pending', 'completed', 'failed', 'refunded'] as const;
+const VALID_METHODS = ['flutterwave_mobile', 'flutterwave_card', 'bank_transfer', 'cash'] as const;
+
+type PaymentFilters = { status?: string; method?: string };
+
 // ── Payments (paginated) ──────────────────────────────────────────────────
-export async function getPayments(page: number) {
+export async function getPayments(page: number, filters: PaymentFilters = {}) {
   await requireRole(['accountant', 'super_admin']);
 
-  const safePage = Math.max(1, page);
+  // Validate filter values against allow-lists; ignore invalid values
+  const statusFilter = VALID_STATUSES.includes(filters.status as (typeof VALID_STATUSES)[number])
+    ? (filters.status as (typeof VALID_STATUSES)[number])
+    : undefined;
+  const methodFilter = VALID_METHODS.includes(filters.method as (typeof VALID_METHODS)[number])
+    ? (filters.method as (typeof VALID_METHODS)[number])
+    : undefined;
+
+  const whereConditions = and(
+    statusFilter ? eq(payments.status, statusFilter) : undefined,
+    methodFilter ? eq(payments.paymentMethod, methodFilter) : undefined,
+  );
+
+  // Compute totalPages from count first, then clamp page at both ends
+  const countRow = await db
+    .select({ value: count() })
+    .from(payments)
+    .where(whereConditions)
+    .then((r) => r[0]);
+
+  const totalPages = Math.max(1, Math.ceil(Number(countRow.value) / PAGE_SIZE));
+  const safePage = Math.min(Math.max(1, page), totalPages);
   const offset = (safePage - 1) * PAGE_SIZE;
 
-  const [countRow, rows] = await Promise.all([
-    db.select({ value: count() }).from(payments).then((r) => r[0]),
-    db
-      .select({
-        id: payments.id,
-        amount: payments.amount,
-        status: payments.status,
-        paymentMethod: payments.paymentMethod,
-        transactionId: payments.transactionId,
-        createdAt: payments.createdAt,
-        // Customer via payments.userId → users
-        customerName: users.name,
-        customerEmail: users.email,
-        // Order reference
-        orderNumber: orders.orderNumber,
-      })
-      .from(payments)
-      .leftJoin(users, eq(payments.userId, users.id))
-      .leftJoin(orders, eq(payments.orderId, orders.id))
-      .orderBy(desc(payments.createdAt))
-      .limit(PAGE_SIZE)
-      .offset(offset),
-  ]);
+  const rows = await db
+    .select({
+      id: payments.id,
+      amount: payments.amount,
+      status: payments.status,
+      paymentMethod: payments.paymentMethod,
+      transactionId: payments.transactionId,
+      createdAt: payments.createdAt,
+      // Customer via payments.userId → users
+      customerName: users.name,
+      customerEmail: users.email,
+      // Order reference
+      orderNumber: orders.orderNumber,
+    })
+    .from(payments)
+    .where(whereConditions)
+    .leftJoin(users, eq(payments.userId, users.id))
+    .leftJoin(orders, eq(payments.orderId, orders.id))
+    .orderBy(desc(payments.createdAt))
+    .limit(PAGE_SIZE)
+    .offset(offset);
 
   return {
     total: Number(countRow.value),
-    totalPages: Math.max(1, Math.ceil(Number(countRow.value) / PAGE_SIZE)),
+    totalPages,
     page: safePage,
     rows: rows.map((r) => ({
       ...r,
@@ -197,6 +222,24 @@ export async function getReceivables() {
       totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
     })),
   };
+}
+
+// ── Client List (read-only) ───────────────────────────────────────────────
+export async function getClientListReadonly() {
+  await requireRole(['accountant', 'super_admin']);
+
+  return db
+    .select({
+      id: clients.id,
+      name: clients.name,
+      email: clients.email,
+      phone: clients.phone,
+      city: clients.city,
+      status: clients.status,
+    })
+    .from(clients)
+    .where(isNull(clients.deletedAt))
+    .orderBy(clients.name);
 }
 
 // ── Job Status Summary ────────────────────────────────────────────────────

--- a/src/app/accounts/clients/page.tsx
+++ b/src/app/accounts/clients/page.tsx
@@ -1,0 +1,79 @@
+import { getClientListReadonly } from '../actions';
+
+function statusBadge(status: string) {
+  const map: Record<string, string> = {
+    active: 'bg-green-50 text-green-700',
+    lead: 'bg-blue-50 text-blue-700',
+    inactive: 'bg-gray-100 text-gray-500',
+  };
+  const labels: Record<string, string> = {
+    active: 'Active',
+    lead: 'Lead',
+    inactive: 'Inactive',
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${map[status] ?? 'bg-gray-100 text-gray-600'}`}
+    >
+      {labels[status] ?? status}
+    </span>
+  );
+}
+
+export default async function AccountsClientsPage() {
+  const clientList = await getClientListReadonly();
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Clients</h2>
+        <p className="text-gray-500 text-sm mt-1">
+          {clientList.length} client{clientList.length !== 1 ? 's' : ''} — read-only view
+        </p>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        {clientList.length === 0 ? (
+          <div className="p-16 text-center text-sm text-gray-400">No clients on record yet</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Name
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Contact
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    City
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {clientList.map((c) => (
+                  <tr key={c.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-3 text-sm font-medium text-gray-900">{c.name}</td>
+                    <td className="px-6 py-3">
+                      {c.email && <p className="text-sm text-gray-700">{c.email}</p>}
+                      {c.phone && <p className="text-xs text-gray-400">{c.phone}</p>}
+                      {!c.email && !c.phone && <span className="text-sm text-gray-400">—</span>}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-600">{c.city ?? '—'}</td>
+                    <td className="px-6 py-3">{statusBadge(c.status)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/accounts/layout.tsx
+++ b/src/app/accounts/layout.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth';
+import { homeForRole } from '@/lib/roles';
+
+export default async function AccountsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+  if (!session?.user) {
+    redirect('/auth/login');
+  }
+
+  const role = (session.user as { role?: string }).role;
+  if (role !== 'accountant') {
+    redirect(homeForRole(role));
+  }
+
+  return (
+    <div className="min-h-dvh bg-slate-50">
+      <header className="bg-[#00477A] text-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Accounts Dashboard</p>
+          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/accounts/layout.tsx
+++ b/src/app/accounts/layout.tsx
@@ -1,6 +1,10 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getSession } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { auth, getSession } from '@/lib/auth';
 import { homeForRole } from '@/lib/roles';
+import { AccountsNav } from '@/components/dashboard/AccountsNav';
+import { LogOut, Globe } from 'lucide-react';
 
 export default async function AccountsLayout({
   children,
@@ -13,18 +17,56 @@ export default async function AccountsLayout({
   }
 
   const role = (session.user as { role?: string }).role;
-  if (role !== 'accountant') {
+  if (role !== 'accountant' && role !== 'super_admin') {
     redirect(homeForRole(role));
   }
+
+  const initial = session.user.name?.[0]?.toUpperCase() ?? 'A';
 
   return (
     <div className="min-h-dvh bg-slate-50">
       <header className="bg-[#00477A] text-white">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
-          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Accounts Dashboard</p>
-          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Accounts Dashboard</p>
+            <h1 className="text-xl font-bold mt-0.5 truncate">{session.user.name}</h1>
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+            >
+              <Globe size={16} />
+              <span className="hidden sm:inline">Website</span>
+            </Link>
+            <div className="hidden sm:flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-sm font-bold">
+              {initial}
+            </div>
+            <form
+              action={async () => {
+                'use server';
+                await auth.api.signOut({ headers: await headers() });
+                redirect('/auth/login');
+              }}
+            >
+              <button
+                type="submit"
+                className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+              >
+                <LogOut size={16} />
+                <span className="hidden sm:inline">Sign Out</span>
+              </button>
+            </form>
+          </div>
         </div>
       </header>
+
+      <div className="bg-white border-b sticky top-0 z-10">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <AccountsNav />
+        </div>
+      </div>
+
       <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
     </div>
   );

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -1,0 +1,16 @@
+import { ComingSoon } from '@/components/dashboard/ComingSoon';
+
+export default function AccountsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Accounts Overview</h2>
+        <p className="text-sm text-gray-500 mt-1">Invoicing, payments, and financial records.</p>
+      </div>
+      <ComingSoon
+        module="Accounts Dashboard"
+        description="Invoice management, payment tracking, and financial reports will be available here."
+      />
+    </div>
+  );
+}

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -1,5 +1,6 @@
 import { getCashPosition, getReceivables, getJobStatusSummary } from './actions';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
+import { RevenueChart } from '@/components/dashboard/RevenueChart';
 import { TrendingUp, Clock, DollarSign } from 'lucide-react';
 
 function ugx(n: number) {
@@ -115,6 +116,21 @@ export default async function AccountsPage() {
           </div>
         </div>
       )}
+
+      {/* Monthly collection trend */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b">
+          <h3 className="font-semibold text-gray-900">Collected — Last 6 Months</h3>
+          <p className="text-xs text-gray-500 mt-0.5">Completed payments by calendar month</p>
+        </div>
+        <div className="p-4">
+          {cash.monthlyCollected.length > 0 ? (
+            <RevenueChart data={cash.monthlyCollected} />
+          ) : (
+            <p className="py-12 text-center text-sm text-gray-400">No data for the last 6 months</p>
+          )}
+        </div>
+      </div>
 
       {/* Receivables */}
       <div className="bg-white rounded-xl border shadow-sm overflow-hidden">

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -1,16 +1,244 @@
+import { getCashPosition, getReceivables, getJobStatusSummary } from './actions';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
+import { TrendingUp, Clock, DollarSign } from 'lucide-react';
 
-export default function AccountsPage() {
+function ugx(n: number) {
+  return `UGX ${n.toLocaleString('en-UG')}`;
+}
+
+function methodLabel(method: string) {
+  const MAP: Record<string, string> = {
+    flutterwave_mobile: 'Mobile Money',
+    flutterwave_card: 'Card (Flutterwave)',
+    bank_transfer: 'Bank Transfer',
+    cash: 'Cash',
+  };
+  return MAP[method] ?? method;
+}
+
+function statusBadge(status: string) {
+  const classes: Record<string, string> = {
+    assigned: 'bg-blue-50 text-blue-700',
+    in_progress: 'bg-amber-50 text-amber-700',
+    completed: 'bg-green-50 text-green-700',
+    verified: 'bg-emerald-50 text-emerald-700',
+  };
+  const labels: Record<string, string> = {
+    assigned: 'Assigned',
+    in_progress: 'In Progress',
+    completed: 'Completed',
+    verified: 'Verified',
+  };
   return (
-    <div className="space-y-6">
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${classes[status] ?? 'bg-gray-100 text-gray-700'}`}>
+      {labels[status] ?? status}
+    </span>
+  );
+}
+
+export default async function AccountsPage() {
+  const [cash, receivables, jobSummary] = await Promise.all([
+    getCashPosition(),
+    getReceivables(),
+    getJobStatusSummary(),
+  ]);
+
+  const totalReceivables =
+    receivables.pendingOrders.reduce((s, r) => s + r.total, 0) +
+    receivables.receivableQuotations.reduce((s, r) => s + (r.totalAmount ?? 0), 0);
+
+  return (
+    <div className="space-y-8">
+      {/* Page header */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900">Accounts Overview</h2>
-        <p className="text-sm text-gray-500 mt-1">Invoicing, payments, and financial records.</p>
+        <p className="text-sm text-gray-500 mt-1">Cash position, receivables, and job status — read-only view.</p>
       </div>
-      <ComingSoon
-        module="Accounts Dashboard"
-        description="Invoice management, payment tracking, and financial reports will be available here."
-      />
+
+      {/* Cash cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="bg-white rounded-xl border shadow-sm p-6 flex items-start gap-4">
+          <div className="flex-shrink-0 rounded-full bg-[#009FCE]/10 p-3">
+            <TrendingUp className="text-[#009FCE]" size={20} />
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Collected This Month</p>
+            <p className="text-2xl font-bold text-gray-900 mt-1">{ugx(cash.collectedThisMonth)}</p>
+          </div>
+        </div>
+
+        <div className="bg-white rounded-xl border shadow-sm p-6 flex items-start gap-4">
+          <div className="flex-shrink-0 rounded-full bg-amber-50 p-3">
+            <Clock className="text-amber-600" size={20} />
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Pending Payments</p>
+            <p className="text-2xl font-bold text-gray-900 mt-1">{ugx(cash.pendingTotal)}</p>
+            <p className="text-xs text-gray-400 mt-0.5">{cash.pendingCount} transaction{cash.pendingCount !== 1 ? 's' : ''}</p>
+          </div>
+        </div>
+
+        <div className="bg-white rounded-xl border shadow-sm p-6 flex items-start gap-4">
+          <div className="flex-shrink-0 rounded-full bg-green-50 p-3">
+            <DollarSign className="text-green-600" size={20} />
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500">All-time Collected</p>
+            <p className="text-2xl font-bold text-gray-900 mt-1">{ugx(cash.collectedAllTime)}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Payment method breakdown */}
+      {cash.byMethod.length > 0 && (
+        <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+          <div className="px-6 py-4 border-b">
+            <h3 className="font-semibold text-gray-900">Payment Method Breakdown (Collected)</h3>
+          </div>
+          <div className="divide-y">
+            {cash.byMethod
+              .sort((a, b) => b.total - a.total)
+              .map((row) => {
+                const pct = cash.collectedAllTime > 0
+                  ? Math.round((row.total / cash.collectedAllTime) * 100)
+                  : 0;
+                return (
+                  <div key={row.method} className="px-6 py-4 flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="text-sm font-medium text-gray-700">{methodLabel(row.method)}</span>
+                      <span className="text-xs text-gray-400 hidden sm:inline">{pct}%</span>
+                    </div>
+                    <span className="text-sm font-semibold text-gray-900 whitespace-nowrap">{ugx(row.total)}</span>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      )}
+
+      {/* Receivables */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b flex items-center justify-between">
+          <h3 className="font-semibold text-gray-900">Receivables</h3>
+          <span className="text-sm font-semibold text-[#009FCE]">{ugx(totalReceivables)}</span>
+        </div>
+
+        {/* Pending orders */}
+        {receivables.pendingOrders.length > 0 && (
+          <>
+            <div className="px-6 py-2 bg-gray-50 border-b">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Pending Orders ({receivables.pendingOrders.length})
+              </p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-gray-50 border-b">
+                  <tr>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Order #</th>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Customer</th>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Date</th>
+                    <th className="text-right px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Amount</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {receivables.pendingOrders.map((o) => (
+                    <tr key={o.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-3 text-sm font-mono text-gray-700">{o.orderNumber}</td>
+                      <td className="px-6 py-3">
+                        <p className="text-sm text-gray-900">{o.customerName}</p>
+                        <p className="text-xs text-gray-400">{o.customerEmail}</p>
+                      </td>
+                      <td className="px-6 py-3 text-sm text-gray-500">
+                        {o.createdAt ? new Date(o.createdAt).toLocaleDateString('en-UG', { day: 'numeric', month: 'short', year: 'numeric' }) : '—'}
+                      </td>
+                      <td className="px-6 py-3 text-sm font-semibold text-gray-900 text-right">{ugx(o.total)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+
+        {/* Approved quotations */}
+        {receivables.receivableQuotations.length > 0 && (
+          <>
+            <div className="px-6 py-2 bg-gray-50 border-b border-t">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Approved Quotations ({receivables.receivableQuotations.length})
+              </p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-gray-50 border-b">
+                  <tr>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Quotation #</th>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Customer</th>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Status</th>
+                    <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Date</th>
+                    <th className="text-right px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Amount</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {receivables.receivableQuotations.map((q) => (
+                    <tr key={q.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-3 text-sm font-mono text-gray-700">{q.quotationNumber}</td>
+                      <td className="px-6 py-3">
+                        <p className="text-sm text-gray-900">{q.customerName}</p>
+                        <p className="text-xs text-gray-400">{q.customerEmail}</p>
+                      </td>
+                      <td className="px-6 py-3">
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          q.status === 'converted' ? 'bg-purple-50 text-purple-700' : 'bg-green-50 text-green-700'
+                        }`}>
+                          {q.status === 'converted' ? 'Converted' : 'Approved'}
+                        </span>
+                      </td>
+                      <td className="px-6 py-3 text-sm text-gray-500">
+                        {q.createdAt ? new Date(q.createdAt).toLocaleDateString('en-UG', { day: 'numeric', month: 'short', year: 'numeric' }) : '—'}
+                      </td>
+                      <td className="px-6 py-3 text-sm font-semibold text-gray-900 text-right">
+                        {q.totalAmount != null ? ugx(q.totalAmount) : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+
+        {receivables.pendingOrders.length === 0 && receivables.receivableQuotations.length === 0 && (
+          <div className="p-12 text-center text-sm text-gray-400">No outstanding receivables</div>
+        )}
+      </div>
+
+      {/* Job status summary strip */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b">
+          <h3 className="font-semibold text-gray-900">Active Job Status</h3>
+          <p className="text-xs text-gray-500 mt-0.5">Operational view — read-only</p>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-y sm:divide-y-0">
+          {jobSummary.map((item) => (
+            <div key={item.status} className="px-6 py-5 flex flex-col gap-2">
+              {statusBadge(item.status)}
+              <p className="text-3xl font-bold text-gray-900">{item.count}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Coming soon modules */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-700 mb-4">Coming Soon</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <ComingSoon module="Invoices" description="Generate and manage client invoices." />
+          <ComingSoon module="Expenses" description="Track and categorise operational expenses." />
+          <ComingSoon module="Payroll" description="Staff payroll processing and reports." />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/accounts/payments/page.tsx
+++ b/src/app/accounts/payments/page.tsx
@@ -1,8 +1,6 @@
 import { getPayments } from '../actions';
 import Link from 'next/link';
 
-const PAGE_SIZE = 25;
-
 function ugx(n: number) {
   return `UGX ${n.toLocaleString('en-UG')}`;
 }
@@ -31,15 +29,25 @@ function methodLabel(method: string) {
   return MAP[method] ?? method;
 }
 
+function pageHref(page: number, status: string, method: string) {
+  const params = new URLSearchParams();
+  params.set('page', String(page));
+  if (status) params.set('status', status);
+  if (method) params.set('method', method);
+  return `/accounts/payments?${params.toString()}`;
+}
+
 export default async function PaymentsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string; status?: string; method?: string }>;
 }) {
   const params = await searchParams;
   const page = Math.max(1, parseInt(params.page ?? '1', 10) || 1);
+  const status = params.status ?? '';
+  const method = params.method ?? '';
 
-  const { total, totalPages, rows } = await getPayments(page);
+  const { total, totalPages, page: safePage, rows } = await getPayments(page, { status, method });
 
   return (
     <div className="space-y-6">
@@ -48,6 +56,61 @@ export default async function PaymentsPage({
         <h2 className="text-2xl font-bold text-gray-900">Payments</h2>
         <p className="text-gray-500 text-sm mt-1">{total} total payment{total !== 1 ? 's' : ''}</p>
       </div>
+
+      {/* Filter form — GET, no JS required */}
+      <form method="GET" action="/accounts/payments" className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="status-filter" className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+            Status
+          </label>
+          <select
+            id="status-filter"
+            name="status"
+            defaultValue={status}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+          >
+            <option value="">All statuses</option>
+            <option value="pending">Pending</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+            <option value="refunded">Refunded</option>
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="method-filter" className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+            Method
+          </label>
+          <select
+            id="method-filter"
+            name="method"
+            defaultValue={method}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+          >
+            <option value="">All methods</option>
+            <option value="flutterwave_mobile">Mobile Money</option>
+            <option value="flutterwave_card">Card</option>
+            <option value="bank_transfer">Bank Transfer</option>
+            <option value="cash">Cash</option>
+          </select>
+        </div>
+
+        <button
+          type="submit"
+          className="px-4 py-2 text-sm font-medium bg-[#009FCE] text-white rounded-lg hover:bg-[#0089b3] transition"
+        >
+          Apply
+        </button>
+
+        {(status || method) && (
+          <Link
+            href="/accounts/payments"
+            className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-600 hover:bg-gray-50 transition"
+          >
+            Clear
+          </Link>
+        )}
+      </form>
 
       {/* Table */}
       <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
@@ -106,24 +169,24 @@ export default async function PaymentsPage({
         )}
       </div>
 
-      {/* Pagination */}
+      {/* Pagination — carries filters forward */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
           <p className="text-sm text-gray-500">
-            Page {page} of {totalPages}
+            Page {safePage} of {totalPages}
           </p>
           <div className="flex gap-2">
-            {page > 1 && (
+            {safePage > 1 && (
               <Link
-                href={`/accounts/payments?page=${page - 1}`}
+                href={pageHref(safePage - 1, status, method)}
                 className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-700 hover:bg-gray-50 transition"
               >
                 ← Prev
               </Link>
             )}
-            {page < totalPages && (
+            {safePage < totalPages && (
               <Link
-                href={`/accounts/payments?page=${page + 1}`}
+                href={pageHref(safePage + 1, status, method)}
                 className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-700 hover:bg-gray-50 transition"
               >
                 Next →

--- a/src/app/accounts/payments/page.tsx
+++ b/src/app/accounts/payments/page.tsx
@@ -1,0 +1,137 @@
+import { getPayments } from '../actions';
+import Link from 'next/link';
+
+const PAGE_SIZE = 25;
+
+function ugx(n: number) {
+  return `UGX ${n.toLocaleString('en-UG')}`;
+}
+
+function statusBadge(status: string) {
+  const map: Record<string, string> = {
+    completed: 'bg-green-50 text-green-700',
+    pending: 'bg-amber-50 text-amber-700',
+    failed: 'bg-red-50 text-red-700',
+    refunded: 'bg-purple-50 text-purple-700',
+  };
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${map[status] ?? 'bg-gray-100 text-gray-600'}`}>
+      {status}
+    </span>
+  );
+}
+
+function methodLabel(method: string) {
+  const MAP: Record<string, string> = {
+    flutterwave_mobile: 'Mobile Money',
+    flutterwave_card: 'Card',
+    bank_transfer: 'Bank Transfer',
+    cash: 'Cash',
+  };
+  return MAP[method] ?? method;
+}
+
+export default async function PaymentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const params = await searchParams;
+  const page = Math.max(1, parseInt(params.page ?? '1', 10) || 1);
+
+  const { total, totalPages, rows } = await getPayments(page);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Payments</h2>
+        <p className="text-gray-500 text-sm mt-1">{total} total payment{total !== 1 ? 's' : ''}</p>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        {rows.length === 0 ? (
+          <div className="p-16 text-center text-sm text-gray-400">No payments recorded yet</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Date</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Customer</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Method</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Status</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Reference</th>
+                  <th className="text-right px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Amount</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((p) => (
+                  <tr key={p.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-3 text-sm text-gray-500 whitespace-nowrap">
+                      {p.createdAt
+                        ? new Date(p.createdAt).toLocaleDateString('en-UG', {
+                            day: 'numeric',
+                            month: 'short',
+                            year: 'numeric',
+                          })
+                        : '—'}
+                    </td>
+                    <td className="px-6 py-3">
+                      <p className="text-sm text-gray-900">{p.customerName ?? '—'}</p>
+                      {p.customerEmail && (
+                        <p className="text-xs text-gray-400">{p.customerEmail}</p>
+                      )}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-700">{methodLabel(p.paymentMethod)}</td>
+                    <td className="px-6 py-3">{statusBadge(p.status ?? 'pending')}</td>
+                    <td className="px-6 py-3 text-xs font-mono text-gray-400">
+                      {p.orderNumber ? (
+                        <span title="Order number">{p.orderNumber}</span>
+                      ) : p.transactionId ? (
+                        <span title="Transaction ID">{p.transactionId.slice(0, 16)}{p.transactionId.length > 16 ? '…' : ''}</span>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td className="px-6 py-3 text-sm font-semibold text-gray-900 text-right whitespace-nowrap">
+                      {ugx(p.amount)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Link
+                href={`/accounts/payments?page=${page - 1}`}
+                className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-700 hover:bg-gray-50 transition"
+              >
+                ← Prev
+              </Link>
+            )}
+            {page < totalPages && (
+              <Link
+                href={`/accounts/payments?page=${page + 1}`}
+                className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-700 hover:bg-gray-50 transition"
+              >
+                Next →
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,118 @@
+import { db } from '@/db';
+import { auditLogs } from '@/db/schema';
+import { count, desc } from 'drizzle-orm';
+import { requireRole } from '@/lib/auth';
+import Link from 'next/link';
+import { format } from 'date-fns';
+
+const PAGE_SIZE = 25;
+
+export default async function AuditLogsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  await requireRole(['super_admin']);
+
+  const params = await searchParams;
+  const page = Math.max(1, parseInt(params.page ?? '1', 10) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const [[totalRow], logs] = await Promise.all([
+    db.select({ value: count() }).from(auditLogs),
+    db.query.auditLogs.findMany({
+      orderBy: [desc(auditLogs.createdAt)],
+      limit: PAGE_SIZE,
+      offset,
+      with: { user: { columns: { firstName: true, lastName: true, email: true } } },
+    }),
+  ]);
+
+  const total = Number(totalRow.value);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Audit Logs</h2>
+        <p className="text-gray-500 text-sm mt-1">{total} total events</p>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        {logs.length === 0 ? (
+          <div className="p-16 text-center text-sm text-gray-400">No audit events yet</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">User</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Action</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Resource Type</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Resource ID</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">IP Address</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Time</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {logs.map((log) => (
+                  <tr key={log.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-3 text-sm text-gray-700">
+                      {log.user
+                        ? `${log.user.firstName} ${log.user.lastName}`
+                        : log.userId
+                          ? <span className="font-mono text-xs text-gray-400">{log.userId.slice(0, 8)}…</span>
+                          : '—'}
+                    </td>
+                    <td className="px-6 py-3">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700">
+                        {log.action}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-600">{log.resourceType}</td>
+                    <td className="px-6 py-3 text-xs font-mono text-gray-400">
+                      {log.resourceId ? log.resourceId.slice(0, 8) + '…' : '—'}
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-500">{log.ipAddress ?? '—'}</td>
+                    <td className="px-6 py-3 text-sm text-gray-500">
+                      {log.createdAt ? format(new Date(log.createdAt), 'MMM d yyyy, HH:mm') : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Link
+                href={`/admin/audit?page=${page - 1}`}
+                className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-700 hover:bg-gray-50 transition"
+              >
+                ← Prev
+              </Link>
+            )}
+            {page < totalPages && (
+              <Link
+                href={`/admin/audit?page=${page + 1}`}
+                className="px-4 py-2 text-sm font-medium bg-white border rounded-lg text-gray-700 hover:bg-gray-50 transition"
+              >
+                Next →
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -14,7 +14,7 @@ function toCoord(value: FormDataEntryValue | null): number | null {
 
 const POOL_TYPES = ['concrete', 'fiberglass', 'vinyl', 'other'];
 const STATUSES = ['lead', 'active', 'inactive'];
-const MANAGER_ROLES = ['manager', 'admin', 'super_admin'];
+const MANAGER_ROLES = ['manager', 'super_admin'];
 
 const statusColors: Record<string, string> = {
   lead: 'bg-yellow-100 text-yellow-800',

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -2,15 +2,15 @@ import { db } from '@/db';
 import { clients } from '@/db/schema/clients';
 import { isNull } from 'drizzle-orm';
 import { requireRole } from '@/lib/auth';
-import { getJobs, getActiveAttendants } from '@/lib/work';
+import { getJobs, getActiveTechnicians } from '@/lib/work';
 import { JobsBoard } from '@/components/dashboard/JobsBoard';
 
 export default async function AdminJobsPage() {
-  await requireRole(['admin', 'super_admin']);
+  await requireRole(['super_admin']);
 
   const [jobs, attendants, clientRows] = await Promise.all([
     getJobs(null),
-    getActiveAttendants(),
+    getActiveTechnicians(),
     db.select({ userId: clients.userId, name: clients.name }).from(clients).where(isNull(clients.deletedAt)),
   ]);
 
@@ -21,7 +21,7 @@ export default async function AdminJobsPage() {
     <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-bold text-gray-900">Service Requests</h2>
-        <p className="text-gray-500 text-sm mt-1">Assign attendants, track progress, and verify completed work across all clients.</p>
+        <p className="text-gray-500 text-sm mt-1">Assign technicians, track progress, and verify completed work across all clients.</p>
       </div>
       <JobsBoard jobs={jobs} attendants={attendants} clientNameByUserId={clientNameByUserId} path="/admin/jobs" />
     </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -16,7 +16,7 @@ export default async function AdminLayout({
   }
 
   // Check role
-  if (session.user.role !== 'super_admin' && session.user.role !== 'admin') {
+  if (session.user.role !== 'super_admin') {
     redirect("/")
   }
 

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { LayoutDashboard, ShoppingBag, Package, FolderKanban, FileText, Settings, Users, Contact, ArrowLeft, ClipboardList, MessagesSquare, Globe } from "lucide-react"
+import { LayoutDashboard, ShoppingBag, Package, FolderKanban, FileText, Settings, Users, Contact, ArrowLeft, ClipboardList, MessagesSquare, Globe, ScrollText, ShieldCheck } from "lucide-react"
 import { auth, getSession } from "@/lib/auth"
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
@@ -29,55 +29,54 @@ export default async function AdminLayout({
           <p className="text-xs text-gray-400 mt-1">Super Admin Dashboard</p>
         </div>
         
-        <nav className="p-4 space-y-2">
+        <nav className="p-4 space-y-1">
+          {/* System group */}
           <Link href="/admin" className="flex items-center gap-3 px-4 py-3 rounded-lg bg-gray-800 text-white hover:bg-gray-700 transition-colors">
             <LayoutDashboard size={20} />
-            <span>Dashboard</span>
+            <span>Overview</span>
           </Link>
-          
+          <Link href="/admin/users" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
+            <ShieldCheck size={20} />
+            <span>Users &amp; Roles</span>
+          </Link>
+          <Link href="/admin/audit" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
+            <ScrollText size={20} />
+            <span>Audit Logs</span>
+          </Link>
+          <Link href="/admin/settings" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
+            <Settings size={20} />
+            <span>System Settings</span>
+          </Link>
+
+          {/* All Data group */}
+          <p className="px-4 pt-5 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-500">All Data</p>
           <Link href="/admin/clients" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
             <Contact size={20} />
             <span>Clients</span>
           </Link>
-
-          <Link href="/admin/orders" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
-            <ShoppingBag size={20} />
-            <span>Orders</span>
-          </Link>
-
           <Link href="/admin/jobs" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
             <ClipboardList size={20} />
             <span>Service Requests</span>
           </Link>
-
-          <Link href="/admin/messages" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
-            <MessagesSquare size={20} />
-            <span>Messages</span>
+          <Link href="/admin/orders" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
+            <ShoppingBag size={20} />
+            <span>Orders</span>
           </Link>
-
           <Link href="/admin/products" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
             <Package size={20} />
             <span>Products</span>
           </Link>
-          
           <Link href="/admin/projects" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
             <FolderKanban size={20} />
             <span>Projects</span>
           </Link>
-          
           <Link href="/admin/blog" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
             <FileText size={20} />
             <span>Blog</span>
           </Link>
-          
-          <Link href="/admin/users" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
-            <Users size={20} />
-            <span>Users</span>
-          </Link>
-          
-          <Link href="/admin/settings" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
-            <Settings size={20} />
-            <span>Settings</span>
+          <Link href="/admin/messages" className="flex items-center gap-3 px-4 py-3 rounded-lg text-gray-300 hover:bg-gray-800 hover:text-white transition-colors">
+            <MessagesSquare size={20} />
+            <span>Messages</span>
           </Link>
         </nav>
         

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { LayoutDashboard, ShoppingBag, Package, FolderKanban, FileText, Settings, Users, Contact, ArrowLeft, ClipboardList, MessagesSquare, Globe, ScrollText, ShieldCheck } from "lucide-react"
+import { LayoutDashboard, ShoppingBag, Package, FolderKanban, FileText, Settings, Contact, ArrowLeft, ClipboardList, MessagesSquare, Globe, ScrollText, ShieldCheck } from "lucide-react"
 import { auth, getSession } from "@/lib/auth"
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@ import { LayoutDashboard, ShoppingBag, Package, FolderKanban, FileText, Settings
 import { auth, getSession } from "@/lib/auth"
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"
+import { homeForRole } from "@/lib/roles"
 
 export default async function AdminLayout({
   children,
@@ -17,7 +18,7 @@ export default async function AdminLayout({
 
   // Check role
   if (session.user.role !== 'super_admin') {
-    redirect("/")
+    redirect(homeForRole(session.user.role))
   }
 
   return (

--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -6,7 +6,7 @@ import { getThreads } from '@/lib/work';
 import { MessagesPanel } from '@/components/dashboard/MessagesPanel';
 
 export default async function AdminMessagesPage() {
-  await requireRole(['admin', 'super_admin']);
+  await requireRole(['super_admin']);
 
   const [threadsMap, clientRows] = await Promise.all([
     getThreads(null),

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,124 +1,198 @@
 import { db } from '@/db';
-import { users, orders, products, blogPosts, projects } from '@/db/schema';
-import { count, isNull, eq } from 'drizzle-orm';
-import { getSession } from '@/lib/auth';
+import { users, sessions, auditLogs } from '@/db/schema';
+import { count, eq, gt, isNull } from 'drizzle-orm';
+import { requireRole } from '@/lib/auth';
 import Link from 'next/link';
-import { Users, ShoppingBag, Package, FileText, FolderKanban, DollarSign } from 'lucide-react';
+import { Users, Monitor, Database, UserPlus, KeyRound, Shield } from 'lucide-react';
+import { RoleBarChart } from '@/components/admin/RoleBarChart';
+import { format } from 'date-fns';
 
-export default async function AdminDashboard() {
-  const session = await getSession();
+export default async function AdminOverview() {
+  await requireRole(['super_admin']);
 
-  // Run all stat queries in parallel for faster load
+  const now = new Date();
+
+  // DB health: trivial query
+  let dbHealthy = true;
+  try {
+    await db.select({ value: count() }).from(users).limit(1);
+  } catch {
+    dbHealthy = false;
+  }
+
   const [
-    [userCount],
-    [orderCount],
-    [productCount],
-    [postCount],
-    [projectCount],
-    [pendingOrders],
-    recentUsers,
+    [activeUsersRow],
+    [liveSessionsRow],
+    roleRows,
+    recentLogs,
   ] = await Promise.all([
-    db.select({ value: count() }).from(users).where(isNull(users.deletedAt)),
-    db.select({ value: count() }).from(orders).where(isNull(orders.deletedAt)),
-    db.select({ value: count() }).from(products).where(isNull(products.deletedAt)),
-    db.select({ value: count() }).from(blogPosts).where(isNull(blogPosts.deletedAt)),
-    db.select({ value: count() }).from(projects).where(isNull(projects.deletedAt)),
-    db.select({ value: count() }).from(orders).where(eq(orders.status, 'pending')),
-    db.query.users.findMany({
-      where: isNull(users.deletedAt),
-      orderBy: (users, { desc }) => [desc(users.createdAt)],
-      limit: 5,
+    db.select({ value: count() }).from(users).where(eq(users.isActive, true)),
+    db.select({ value: count() }).from(sessions).where(gt(sessions.expiresAt, now)),
+    // Count users grouped by role (exclude super_admin)
+    db
+      .select({ role: users.role, value: count() })
+      .from(users)
+      .where(isNull(users.deletedAt))
+      .groupBy(users.role),
+    // Latest 8 audit log rows with optional user join
+    db.query.auditLogs.findMany({
+      orderBy: (t, { desc }) => [desc(t.createdAt)],
+      limit: 8,
+      with: { user: { columns: { firstName: true, lastName: true, email: true } } },
     }),
   ]);
 
+  const roleData = roleRows
+    .filter((r) => r.role !== 'super_admin')
+    .map((r) => ({ role: r.role ?? 'unknown', count: Number(r.value) }))
+    .sort((a, b) => b.count - a.count);
+
   const stats = [
-    { label: 'Total Users', value: userCount.value, icon: Users, href: '/admin/users', color: 'bg-blue-500' },
-    { label: 'Orders', value: orderCount.value, icon: ShoppingBag, href: '/admin/orders', color: 'bg-green-500' },
-    { label: 'Products', value: productCount.value, icon: Package, href: '/admin/products', color: 'bg-purple-500' },
-    { label: 'Blog Posts', value: postCount.value, icon: FileText, href: '/admin/blog', color: 'bg-orange-500' },
-    { label: 'Projects', value: projectCount.value, icon: FolderKanban, href: '/admin/projects', color: 'bg-indigo-500' },
-    { label: 'Pending Orders', value: pendingOrders.value, icon: DollarSign, href: '/admin/orders', color: 'bg-yellow-500' },
+    {
+      label: 'Active Users',
+      value: activeUsersRow.value,
+      icon: Users,
+      color: 'bg-[#009FCE]',
+      href: '/admin/users',
+    },
+    {
+      label: 'Live Sessions',
+      value: liveSessionsRow.value,
+      icon: Monitor,
+      color: 'bg-[#00477A]',
+      href: null,
+    },
+    {
+      label: 'Database',
+      value: dbHealthy ? 'Healthy' : 'Error',
+      icon: Database,
+      color: dbHealthy ? 'bg-green-500' : 'bg-red-500',
+      href: null,
+    },
   ];
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold text-gray-900">
-          Welcome back, {session?.user?.name?.split(' ')[0]}! 👋
-        </h2>
-        <p className="text-gray-500 text-sm mt-1">Here&apos;s what&apos;s happening with your platform today.</p>
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">System Overview</h2>
+          <p className="text-gray-500 text-sm mt-1">System health &amp; user management</p>
+        </div>
+        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-[#009FCE]/10 text-[#00477A] border border-[#009FCE]/30">
+          Super Admin
+        </span>
       </div>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {stats.map((stat) => (
-          <Link key={stat.label} href={stat.href} className="group">
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {stats.map((stat) => {
+          const card = (
             <div className="bg-white rounded-xl border p-5 shadow-sm hover:shadow-md transition-shadow">
               <div className="flex items-center gap-4">
                 <div className={`${stat.color} p-3 rounded-lg text-white`}>
                   <stat.icon size={22} />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-500">{stat.label}</p>
-                  <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">{stat.label}</p>
+                  <p className="text-2xl font-bold text-gray-900 mt-0.5">{stat.value}</p>
                 </div>
               </div>
             </div>
-          </Link>
-        ))}
+          );
+          return stat.href ? (
+            <Link key={stat.label} href={stat.href} className="group">
+              {card}
+            </Link>
+          ) : (
+            <div key={stat.label}>{card}</div>
+          );
+        })}
       </div>
 
-      {/* Recent Users */}
-      <div className="bg-white rounded-xl border shadow-sm">
-        <div className="p-5 border-b flex items-center justify-between">
-          <h3 className="font-semibold text-gray-900">Recent Users</h3>
-          <Link href="/admin/users" className="text-sm text-blue-600 hover:text-blue-800">View all →</Link>
-        </div>
-        <div className="divide-y">
-          {recentUsers.map((user) => (
-            <div key={user.id} className="p-4 flex items-center justify-between hover:bg-gray-50">
-              <div className="flex items-center gap-3">
-                <div className="h-9 w-9 rounded-full bg-blue-500 flex items-center justify-center text-white text-xs font-bold">
-                  {user.firstName[0]}{user.lastName[0]}
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-gray-900">{user.firstName} {user.lastName}</p>
-                  <p className="text-xs text-gray-500">{user.email}</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                  {user.role || 'No role'}
-                </span>
-                <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${user.isActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
-                  {user.isActive ? 'Active' : 'Inactive'}
-                </span>
-              </div>
-            </div>
-          ))}
-          {recentUsers.length === 0 && (
-            <div className="p-8 text-center text-gray-500 text-sm">No users yet</div>
+      {/* Middle row: Users by Role + Quick Actions */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* Users by Role bar chart */}
+        <div className="md:col-span-2 bg-white rounded-xl border p-5 shadow-sm">
+          <h3 className="font-semibold text-gray-900 mb-4">Users by Role</h3>
+          {roleData.length === 0 ? (
+            <p className="text-sm text-gray-400 py-8 text-center">No user data yet</p>
+          ) : (
+            <RoleBarChart data={roleData} />
           )}
         </div>
+
+        {/* Quick Actions */}
+        <div className="bg-white rounded-xl border p-5 shadow-sm">
+          <h3 className="font-semibold text-gray-900 mb-4">Quick Actions</h3>
+          <div className="space-y-3">
+            <Link
+              href="/admin/users?action=create"
+              className="flex items-center gap-3 w-full px-4 py-3 bg-[#009FCE] text-white text-sm font-medium rounded-lg hover:bg-[#0089b5] transition"
+            >
+              <UserPlus size={18} />
+              Create User
+            </Link>
+            <Link
+              href="/admin/users"
+              className="flex items-center gap-3 w-full px-4 py-3 bg-gray-100 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-200 transition"
+            >
+              <KeyRound size={18} />
+              Reset Password
+            </Link>
+            <Link
+              href="/admin/users"
+              className="flex items-center gap-3 w-full px-4 py-3 bg-gray-100 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-200 transition"
+            >
+              <Shield size={18} />
+              Manage Roles
+            </Link>
+          </div>
+        </div>
       </div>
 
-      {/* Quick Actions */}
-      <div className="bg-white rounded-xl border p-5 shadow-sm">
-        <h3 className="font-semibold text-gray-900 mb-4">Quick Actions</h3>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <Link href="/admin/users?action=create" className="flex flex-col items-center gap-2 p-4 rounded-lg border hover:bg-blue-50 hover:border-blue-200 transition">
-            <Users size={20} className="text-blue-600" /> <span className="text-xs font-medium text-gray-700">Add User</span>
-          </Link>
-          <Link href="/admin/products?action=create" className="flex flex-col items-center gap-2 p-4 rounded-lg border hover:bg-purple-50 hover:border-purple-200 transition">
-            <Package size={20} className="text-purple-600" /> <span className="text-xs font-medium text-gray-700">Add Product</span>
-          </Link>
-          <Link href="/admin/blog?action=create" className="flex flex-col items-center gap-2 p-4 rounded-lg border hover:bg-orange-50 hover:border-orange-200 transition">
-            <FileText size={20} className="text-orange-600" /> <span className="text-xs font-medium text-gray-700">New Post</span>
-          </Link>
-          <Link href="/admin/projects?action=create" className="flex flex-col items-center gap-2 p-4 rounded-lg border hover:bg-indigo-50 hover:border-indigo-200 transition">
-            <FolderKanban size={20} className="text-indigo-600" /> <span className="text-xs font-medium text-gray-700">New Project</span>
+      {/* Recent Audit Logs */}
+      <div className="bg-white rounded-xl border shadow-sm">
+        <div className="p-5 border-b flex items-center justify-between">
+          <h3 className="font-semibold text-gray-900">Recent Audit Logs</h3>
+          <Link href="/admin/audit" className="text-sm text-[#009FCE] hover:text-[#00477A]">
+            View all →
           </Link>
         </div>
+        {recentLogs.length === 0 ? (
+          <div className="p-10 text-center text-sm text-gray-400">No audit events yet</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">User</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Action</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Resource</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Time</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {recentLogs.map((log) => (
+                  <tr key={log.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-3 text-sm text-gray-700">
+                      {log.user ? `${log.user.firstName} ${log.user.lastName}` : log.userId ?? '—'}
+                    </td>
+                    <td className="px-6 py-3">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700">
+                        {log.action}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-sm text-gray-600">{log.resourceType}</td>
+                    <td className="px-6 py-3 text-sm text-gray-500">
+                      {log.createdAt ? format(new Date(log.createdAt), 'MMM d, HH:mm') : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 import { db } from '@/db';
 import { users, sessions, auditLogs } from '@/db/schema';
-import { count, eq, gt, isNull } from 'drizzle-orm';
+import { and, count, eq, gt, isNull } from 'drizzle-orm';
 import { requireRole } from '@/lib/auth';
 import Link from 'next/link';
 import { Users, Monitor, Database, UserPlus, KeyRound, Shield } from 'lucide-react';
@@ -12,21 +12,14 @@ export default async function AdminOverview() {
 
   const now = new Date();
 
-  // DB health: trivial query
-  let dbHealthy = true;
-  try {
-    await db.select({ value: count() }).from(users).limit(1);
-  } catch {
-    dbHealthy = false;
-  }
-
   const [
     [activeUsersRow],
     [liveSessionsRow],
     roleRows,
     recentLogs,
+    dbHealthy,
   ] = await Promise.all([
-    db.select({ value: count() }).from(users).where(eq(users.isActive, true)),
+    db.select({ value: count() }).from(users).where(and(eq(users.isActive, true), isNull(users.deletedAt))),
     db.select({ value: count() }).from(sessions).where(gt(sessions.expiresAt, now)),
     // Count users grouped by role (exclude super_admin)
     db
@@ -40,6 +33,7 @@ export default async function AdminOverview() {
       limit: 8,
       with: { user: { columns: { firstName: true, lastName: true, email: true } } },
     }),
+    db.select({ value: count() }).from(users).limit(1).then(() => true).catch(() => false),
   ]);
 
   const roleData = roleRows
@@ -176,7 +170,11 @@ export default async function AdminOverview() {
                 {recentLogs.map((log) => (
                   <tr key={log.id} className="hover:bg-gray-50">
                     <td className="px-6 py-3 text-sm text-gray-700">
-                      {log.user ? `${log.user.firstName} ${log.user.lastName}` : log.userId ?? '—'}
+                      {log.user
+                        ? `${log.user.firstName} ${log.user.lastName}`
+                        : log.userId
+                          ? <span className="font-mono text-xs text-gray-400">{log.userId.slice(0, 8)}…</span>
+                          : '—'}
                     </td>
                     <td className="px-6 py-3">
                       <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700">

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -9,7 +9,7 @@ import { PasswordField } from '@/components/admin/PasswordField';
 import Link from 'next/link';
 
 // super_admin is reserved and cannot be assigned through this UI.
-const ASSIGNABLE_ROLES = ['admin', 'manager', 'attendant', 'customer'] as const;
+const ASSIGNABLE_ROLES = ['director', 'manager', 'sales_manager', 'accountant', 'receptionist', 'technician', 'customer'] as const;
 type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
 
 function toAssignableRole(value: string): AssignableRole {
@@ -185,7 +185,9 @@ export default async function UsersPage({
                 >
                   <option value="">Select Role</option>
                   {ASSIGNABLE_ROLES.map((r) => (
-                    <option key={r} value={r}>{r}</option>
+                    <option key={r} value={r}>
+                      {r.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                    </option>
                   ))}
                 </select>
               </div>

--- a/src/app/director/actions.ts
+++ b/src/app/director/actions.ts
@@ -149,6 +149,7 @@ export async function getDepartmentPerformance() {
 
   return {
     technicianPerformance: technicianJobs.map((r) => ({
+      technicianId: r.technicianId,
       name: `${r.firstName} ${r.lastName}`.trim(),
       completedJobs: Number(r.completedCount),
     })),

--- a/src/app/director/actions.ts
+++ b/src/app/director/actions.ts
@@ -1,0 +1,193 @@
+'use server';
+
+import { db } from '@/db';
+import { clients } from '@/db/schema/clients';
+import { quotations } from '@/db/schema/quotations';
+import { payments } from '@/db/schema/payments';
+import { orders } from '@/db/schema/orders';
+import { users } from '@/db/schema/auth';
+import { count, eq, inArray, isNull, sum, and, desc, gte, sql } from 'drizzle-orm';
+import { requireRole } from '@/lib/auth';
+
+// ── Company Overview ───────────────────────────────────────────────────────
+export async function getCompanyOverview() {
+  await requireRole(['director', 'super_admin']);
+
+  const sixMonthsAgo = new Date();
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+  sixMonthsAgo.setDate(1);
+  sixMonthsAgo.setHours(0, 0, 0, 0);
+
+  const [
+    revenueRow,
+    monthlyRevenue,
+    jobsByStatus,
+    [ordersRow],
+    clientsByStatus,
+  ] = await Promise.all([
+    // Total revenue from completed payments
+    db
+      .select({ total: sum(payments.amount) })
+      .from(payments)
+      .where(eq(payments.status, 'completed'))
+      .then((rows) => rows[0]),
+
+    // Monthly revenue last 6 months
+    db
+      .select({
+        month: sql<string>`to_char(${payments.createdAt}, 'Mon YYYY')`,
+        monthSort: sql<string>`to_char(${payments.createdAt}, 'YYYY-MM')`,
+        total: sum(payments.amount),
+      })
+      .from(payments)
+      .where(and(eq(payments.status, 'completed'), gte(payments.createdAt, sixMonthsAgo)))
+      .groupBy(
+        sql`to_char(${payments.createdAt}, 'Mon YYYY')`,
+        sql`to_char(${payments.createdAt}, 'YYYY-MM')`,
+      )
+      .orderBy(sql`to_char(${payments.createdAt}, 'YYYY-MM')`),
+
+    // Active jobs count by status (job lifecycle statuses)
+    db
+      .select({ status: quotations.status, value: count() })
+      .from(quotations)
+      .where(
+        and(
+          isNull(quotations.deletedAt),
+          inArray(quotations.status as any, [
+            'pending', 'assigned', 'in_progress', 'completed', 'verified', 'cancelled',
+          ]),
+        ),
+      )
+      .groupBy(quotations.status),
+
+    // Total orders
+    db.select({ value: count() }).from(orders).where(isNull(orders.deletedAt)),
+
+    // Clients grouped by status
+    db
+      .select({ status: clients.status, value: count() })
+      .from(clients)
+      .where(isNull(clients.deletedAt))
+      .groupBy(clients.status),
+  ]);
+
+  return {
+    totalRevenue: Number(revenueRow?.total ?? 0),
+    monthlyRevenue: monthlyRevenue.map((r) => ({
+      month: r.month,
+      total: Number(r.total ?? 0),
+    })),
+    jobsByStatus: jobsByStatus.map((r) => ({
+      status: r.status ?? 'unknown',
+      count: Number(r.value),
+    })),
+    totalOrders: Number(ordersRow.value),
+    clientsByStatus: clientsByStatus.map((r) => ({
+      status: r.status,
+      count: Number(r.value),
+    })),
+  };
+}
+
+// ── Department Performance ─────────────────────────────────────────────────
+export async function getDepartmentPerformance() {
+  await requireRole(['director', 'super_admin']);
+
+  const sixMonthsAgo = new Date();
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+  sixMonthsAgo.setDate(1);
+  sixMonthsAgo.setHours(0, 0, 0, 0);
+
+  const [technicianJobs, conversionRows, ordersPerMonth] = await Promise.all([
+    // Per-technician completed job counts
+    db
+      .select({
+        technicianId: quotations.assignedTo,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        completedCount: count(),
+      })
+      .from(quotations)
+      .innerJoin(users, eq(quotations.assignedTo, users.id))
+      .where(
+        and(
+          isNull(quotations.deletedAt),
+          inArray(quotations.status as any, ['completed', 'verified']),
+        ),
+      )
+      .groupBy(quotations.assignedTo, users.firstName, users.lastName),
+
+    // Quotation conversion rate: approved+converted vs total
+    db
+      .select({ status: quotations.status, value: count() })
+      .from(quotations)
+      .where(isNull(quotations.deletedAt))
+      .groupBy(quotations.status),
+
+    // Orders per month last 6 months
+    db
+      .select({
+        month: sql<string>`to_char(${orders.createdAt}, 'Mon YYYY')`,
+        monthSort: sql<string>`to_char(${orders.createdAt}, 'YYYY-MM')`,
+        value: count(),
+      })
+      .from(orders)
+      .where(and(isNull(orders.deletedAt), gte(orders.createdAt, sixMonthsAgo)))
+      .groupBy(
+        sql`to_char(${orders.createdAt}, 'Mon YYYY')`,
+        sql`to_char(${orders.createdAt}, 'YYYY-MM')`,
+      )
+      .orderBy(sql`to_char(${orders.createdAt}, 'YYYY-MM')`),
+  ]);
+
+  const totalQuotations = conversionRows.reduce((sum, r) => sum + Number(r.value), 0);
+  const converted = conversionRows
+    .filter((r) => r.status === 'approved' || r.status === 'converted')
+    .reduce((sum, r) => sum + Number(r.value), 0);
+  const conversionRate = totalQuotations > 0 ? Math.round((converted / totalQuotations) * 100) : 0;
+
+  return {
+    technicianPerformance: technicianJobs.map((r) => ({
+      name: `${r.firstName} ${r.lastName}`.trim(),
+      completedJobs: Number(r.completedCount),
+    })),
+    conversionRate,
+    totalQuotations,
+    converted,
+    ordersPerMonth: ordersPerMonth.map((r) => ({
+      month: r.month,
+      count: Number(r.value),
+    })),
+  };
+}
+
+// ── Pending Approvals ──────────────────────────────────────────────────────
+export async function getPendingApprovals() {
+  await requireRole(['director', 'super_admin']);
+
+  const rows = await db
+    .select({
+      id: quotations.id,
+      quotationNumber: quotations.quotationNumber,
+      customerName: quotations.customerName,
+      projectDescription: quotations.projectDescription,
+      location: quotations.location,
+      totalAmount: quotations.totalAmount,
+      status: quotations.status,
+      createdAt: quotations.createdAt,
+    })
+    .from(quotations)
+    .where(
+      and(
+        isNull(quotations.deletedAt),
+        inArray(quotations.status as any, ['pending', 'reviewed']),
+      ),
+    )
+    .orderBy(desc(quotations.createdAt));
+
+  return rows.map((r) => ({
+    ...r,
+    totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
+  }));
+}

--- a/src/app/director/approval-actions.ts
+++ b/src/app/director/approval-actions.ts
@@ -3,27 +3,51 @@
 import { db } from '@/db';
 import { quotations } from '@/db/schema/quotations';
 import { auditLogs } from '@/db/schema/payments';
-import { eq } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function transitionQuotation(
+  quotationId: string,
+  newStatus: 'approved' | 'rejected',
+  userId: string,
+) {
+  if (!quotationId || !UUID_RE.test(quotationId)) throw new Error('Invalid quotation id');
+
+  await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(quotations)
+      .set({ status: newStatus, updatedAt: new Date() })
+      .where(
+        and(
+          eq(quotations.id, quotationId),
+          inArray(quotations.status as any, ['pending', 'reviewed']),
+        ),
+      )
+      .returning({ id: quotations.id });
+
+    if (updated.length === 0) {
+      throw new Error('Quotation is no longer pending approval');
+    }
+
+    await tx.insert(auditLogs).values({
+      userId,
+      action: `quotation.${newStatus}`,
+      resourceType: 'quotation',
+      resourceId: quotationId,
+      newValues: { status: newStatus },
+    });
+  });
+}
 
 export async function approveQuotation(formData: FormData) {
   const session = await requireRole(['director', 'super_admin']);
   const quotationId = formData.get('quotationId') as string;
   if (!quotationId) throw new Error('Missing quotationId');
 
-  await db
-    .update(quotations)
-    .set({ status: 'approved', updatedAt: new Date() })
-    .where(eq(quotations.id, quotationId));
-
-  await db.insert(auditLogs).values({
-    userId: session.user.id,
-    action: 'quotation.approved',
-    resourceType: 'quotation',
-    resourceId: quotationId,
-    newValues: { status: 'approved' },
-  });
+  await transitionQuotation(quotationId, 'approved', session.user.id);
 
   revalidatePath('/director/approvals');
   revalidatePath('/director');
@@ -34,18 +58,7 @@ export async function rejectQuotation(formData: FormData) {
   const quotationId = formData.get('quotationId') as string;
   if (!quotationId) throw new Error('Missing quotationId');
 
-  await db
-    .update(quotations)
-    .set({ status: 'rejected', updatedAt: new Date() })
-    .where(eq(quotations.id, quotationId));
-
-  await db.insert(auditLogs).values({
-    userId: session.user.id,
-    action: 'quotation.rejected',
-    resourceType: 'quotation',
-    resourceId: quotationId,
-    newValues: { status: 'rejected' },
-  });
+  await transitionQuotation(quotationId, 'rejected', session.user.id);
 
   revalidatePath('/director/approvals');
   revalidatePath('/director');

--- a/src/app/director/approval-actions.ts
+++ b/src/app/director/approval-actions.ts
@@ -1,0 +1,52 @@
+'use server';
+
+import { db } from '@/db';
+import { quotations } from '@/db/schema/quotations';
+import { auditLogs } from '@/db/schema/payments';
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth';
+
+export async function approveQuotation(formData: FormData) {
+  const session = await requireRole(['director', 'super_admin']);
+  const quotationId = formData.get('quotationId') as string;
+  if (!quotationId) throw new Error('Missing quotationId');
+
+  await db
+    .update(quotations)
+    .set({ status: 'approved', updatedAt: new Date() })
+    .where(eq(quotations.id, quotationId));
+
+  await db.insert(auditLogs).values({
+    userId: session.user.id,
+    action: 'quotation.approved',
+    resourceType: 'quotation',
+    resourceId: quotationId,
+    newValues: { status: 'approved' },
+  });
+
+  revalidatePath('/director/approvals');
+  revalidatePath('/director');
+}
+
+export async function rejectQuotation(formData: FormData) {
+  const session = await requireRole(['director', 'super_admin']);
+  const quotationId = formData.get('quotationId') as string;
+  if (!quotationId) throw new Error('Missing quotationId');
+
+  await db
+    .update(quotations)
+    .set({ status: 'rejected', updatedAt: new Date() })
+    .where(eq(quotations.id, quotationId));
+
+  await db.insert(auditLogs).values({
+    userId: session.user.id,
+    action: 'quotation.rejected',
+    resourceType: 'quotation',
+    resourceId: quotationId,
+    newValues: { status: 'rejected' },
+  });
+
+  revalidatePath('/director/approvals');
+  revalidatePath('/director');
+}

--- a/src/app/director/approvals/page.tsx
+++ b/src/app/director/approvals/page.tsx
@@ -1,0 +1,98 @@
+import { getPendingApprovals } from '../actions';
+import { approveQuotation, rejectQuotation } from '../approval-actions';
+import { CheckCircle, XCircle, Inbox } from 'lucide-react';
+
+function fmtUGX(amount: number | null) {
+  if (amount === null) return '—';
+  return `UGX ${amount.toLocaleString('en-UG')}`;
+}
+
+function fmtDate(date: Date | null) {
+  if (!date) return '—';
+  return new Date(date).toLocaleDateString('en-UG', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+export default async function ApprovalsPage() {
+  const pending = await getPendingApprovals();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Pending Approvals</h2>
+          <p className="text-sm text-gray-500 mt-1">Quotations requiring your decision</p>
+        </div>
+        {pending.length > 0 && (
+          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-amber-100 text-amber-800">
+            {pending.length} pending
+          </span>
+        )}
+      </div>
+
+      {pending.length === 0 ? (
+        <div className="bg-white rounded-xl border shadow-sm p-16 flex flex-col items-center text-center gap-3">
+          <Inbox size={40} className="text-gray-300" />
+          <p className="text-lg font-semibold text-gray-900">All clear</p>
+          <p className="text-sm text-gray-400">No quotations are waiting for approval right now.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {pending.map((q) => (
+            <div key={q.id} className="bg-white rounded-xl border shadow-sm p-5">
+              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                {/* Details */}
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-xs font-mono text-gray-400">{q.quotationNumber}</span>
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        q.status === 'reviewed'
+                          ? 'bg-purple-100 text-purple-800'
+                          : 'bg-amber-100 text-amber-800'
+                      }`}
+                    >
+                      {q.status}
+                    </span>
+                  </div>
+                  <p className="text-base font-semibold text-gray-900">{q.customerName}</p>
+                  <p className="text-sm text-gray-600 line-clamp-2">{q.projectDescription}</p>
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 pt-1">
+                    {q.location && <span>📍 {q.location}</span>}
+                    <span>Submitted {fmtDate(q.createdAt)}</span>
+                  </div>
+                </div>
+
+                {/* Amount + actions */}
+                <div className="flex flex-col items-end gap-3 shrink-0">
+                  <p className="text-lg font-bold text-gray-900">{fmtUGX(q.totalAmount)}</p>
+                  <div className="flex gap-2">
+                    <form action={approveQuotation}>
+                      <input type="hidden" name="quotationId" value={q.id} />
+                      <button
+                        type="submit"
+                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-green-600 text-white hover:bg-green-700 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500/50"
+                      >
+                        <CheckCircle size={15} />
+                        Approve
+                      </button>
+                    </form>
+                    <form action={rejectQuotation}>
+                      <input type="hidden" name="quotationId" value={q.id} />
+                      <button
+                        type="submit"
+                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-white border border-red-300 text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500/50"
+                      >
+                        <XCircle size={15} />
+                        Reject
+                      </button>
+                    </form>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/director/approvals/page.tsx
+++ b/src/app/director/approvals/page.tsx
@@ -1,6 +1,7 @@
 import { getPendingApprovals } from '../actions';
 import { approveQuotation, rejectQuotation } from '../approval-actions';
-import { CheckCircle, XCircle, Inbox } from 'lucide-react';
+import { Inbox } from 'lucide-react';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
 
 function fmtUGX(amount: number | null) {
   if (amount === null) return '—';
@@ -68,23 +69,19 @@ export default async function ApprovalsPage() {
                   <div className="flex gap-2">
                     <form action={approveQuotation}>
                       <input type="hidden" name="quotationId" value={q.id} />
-                      <button
-                        type="submit"
-                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-green-600 text-white hover:bg-green-700 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500/50"
-                      >
-                        <CheckCircle size={15} />
-                        Approve
-                      </button>
+                      <SubmitButton
+                        label="Approve"
+                        pendingLabel="Approving…"
+                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-green-600 text-white hover:bg-green-700 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500/50 disabled:opacity-60"
+                      />
                     </form>
                     <form action={rejectQuotation}>
                       <input type="hidden" name="quotationId" value={q.id} />
-                      <button
-                        type="submit"
-                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-white border border-red-300 text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500/50"
-                      >
-                        <XCircle size={15} />
-                        Reject
-                      </button>
+                      <SubmitButton
+                        label="Reject"
+                        pendingLabel="Rejecting…"
+                        className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-white border border-red-300 text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500/50 disabled:opacity-60"
+                      />
                     </form>
                   </div>
                 </div>

--- a/src/app/director/layout.tsx
+++ b/src/app/director/layout.tsx
@@ -1,6 +1,10 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getSession } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { auth, getSession } from '@/lib/auth';
 import { homeForRole } from '@/lib/roles';
+import { DirectorNav } from '@/components/dashboard/DirectorNav';
+import { LogOut, Globe } from 'lucide-react';
 
 export default async function DirectorLayout({
   children,
@@ -13,18 +17,56 @@ export default async function DirectorLayout({
   }
 
   const role = (session.user as { role?: string }).role;
-  if (role !== 'director') {
+  if (role !== 'director' && role !== 'super_admin') {
     redirect(homeForRole(role));
   }
+
+  const initial = session.user.name?.[0]?.toUpperCase() ?? 'D';
 
   return (
     <div className="min-h-dvh bg-slate-50">
       <header className="bg-[#00477A] text-white">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
-          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Director Dashboard</p>
-          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Director Dashboard</p>
+            <h1 className="text-xl font-bold mt-0.5 truncate">{session.user.name}</h1>
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+            >
+              <Globe size={16} />
+              <span className="hidden sm:inline">Website</span>
+            </Link>
+            <div className="hidden sm:flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-sm font-bold">
+              {initial}
+            </div>
+            <form
+              action={async () => {
+                'use server';
+                await auth.api.signOut({ headers: await headers() });
+                redirect('/auth/login');
+              }}
+            >
+              <button
+                type="submit"
+                className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+              >
+                <LogOut size={16} />
+                <span className="hidden sm:inline">Sign Out</span>
+              </button>
+            </form>
+          </div>
         </div>
       </header>
+
+      <div className="bg-white border-b sticky top-0 z-10">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <DirectorNav />
+        </div>
+      </div>
+
       <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
     </div>
   );

--- a/src/app/director/layout.tsx
+++ b/src/app/director/layout.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth';
+import { homeForRole } from '@/lib/roles';
+
+export default async function DirectorLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+  if (!session?.user) {
+    redirect('/auth/login');
+  }
+
+  const role = (session.user as { role?: string }).role;
+  if (role !== 'director') {
+    redirect(homeForRole(role));
+  }
+
+  return (
+    <div className="min-h-dvh bg-slate-50">
+      <header className="bg-[#00477A] text-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Director Dashboard</p>
+          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/director/page.tsx
+++ b/src/app/director/page.tsx
@@ -1,16 +1,179 @@
+import Link from 'next/link';
+import { TrendingUp, Briefcase, ShoppingCart, Users, CheckSquare } from 'lucide-react';
+import { getCompanyOverview, getPendingApprovals } from './actions';
+import { RevenueChart } from '@/components/dashboard/RevenueChart';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
 
-export default function DirectorPage() {
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-amber-100 text-amber-800',
+  assigned: 'bg-indigo-100 text-indigo-800',
+  in_progress: 'bg-blue-100 text-blue-800',
+  completed: 'bg-teal-100 text-teal-800',
+  verified: 'bg-green-100 text-green-800',
+  cancelled: 'bg-gray-100 text-gray-600',
+  // approval-workflow statuses
+  reviewed: 'bg-purple-100 text-purple-800',
+  approved: 'bg-green-100 text-green-800',
+  rejected: 'bg-red-100 text-red-800',
+  converted: 'bg-cyan-100 text-cyan-800',
+};
+
+function fmtUGX(amount: number) {
+  return `UGX ${amount.toLocaleString('en-UG')}`;
+}
+
+export default async function DirectorPage() {
+  const [overview, pendingApprovals] = await Promise.all([
+    getCompanyOverview(),
+    getPendingApprovals(),
+  ]);
+
+  const activeClients = overview.clientsByStatus
+    .filter((c) => c.status === 'active')
+    .reduce((sum, c) => sum + c.count, 0);
+
+  const activeJobs = overview.jobsByStatus
+    .filter((j) => j.status === 'assigned' || j.status === 'in_progress')
+    .reduce((sum, j) => sum + j.count, 0);
+
+  const stats = [
+    {
+      label: 'Total Revenue',
+      value: fmtUGX(overview.totalRevenue),
+      icon: TrendingUp,
+      color: 'bg-[#009FCE]',
+    },
+    {
+      label: 'Active Jobs',
+      value: activeJobs,
+      icon: Briefcase,
+      color: 'bg-[#00477A]',
+    },
+    {
+      label: 'Total Orders',
+      value: overview.totalOrders,
+      icon: ShoppingCart,
+      color: 'bg-indigo-500',
+    },
+    {
+      label: 'Active Clients',
+      value: activeClients,
+      icon: Users,
+      color: 'bg-teal-600',
+    },
+  ];
+
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold text-gray-900">Director Overview</h2>
-        <p className="text-sm text-gray-500 mt-1">Company-wide performance and strategic view.</p>
+    <div className="space-y-8">
+      {/* Page heading */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Company Overview</h2>
+          <p className="text-sm text-gray-500 mt-1">Macro view of Afridrop Solutions Ltd</p>
+        </div>
+        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-[#009FCE]/10 text-[#00477A] border border-[#009FCE]/30">
+          Director
+        </span>
       </div>
-      <ComingSoon
-        module="Director Dashboard"
-        description="Company-wide KPIs, financials, and team performance will be available here."
-      />
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats.map((stat) => (
+          <div key={stat.label} className="bg-white rounded-xl border p-5 shadow-sm">
+            <div className="flex items-center gap-4">
+              <div className={`${stat.color} p-3 rounded-lg text-white shrink-0`}>
+                <stat.icon size={22} />
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">{stat.label}</p>
+                <p className="text-xl font-bold text-gray-900 mt-0.5 truncate">{stat.value}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Revenue chart + jobs by status */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="md:col-span-2 bg-white rounded-xl border p-5 shadow-sm">
+          <h3 className="font-semibold text-gray-900 mb-4">Revenue — Last 6 Months</h3>
+          {overview.monthlyRevenue.length === 0 ? (
+            <p className="text-sm text-gray-400 py-8 text-center">No revenue data yet</p>
+          ) : (
+            <RevenueChart data={overview.monthlyRevenue} />
+          )}
+        </div>
+
+        <div className="bg-white rounded-xl border p-5 shadow-sm">
+          <h3 className="font-semibold text-gray-900 mb-4">Jobs by Status</h3>
+          {overview.jobsByStatus.length === 0 ? (
+            <p className="text-sm text-gray-400 py-8 text-center">No jobs yet</p>
+          ) : (
+            <ul className="space-y-2">
+              {overview.jobsByStatus
+                .sort((a, b) => b.count - a.count)
+                .map((item) => (
+                  <li key={item.status} className="flex items-center justify-between gap-2">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium capitalize ${
+                        STATUS_COLORS[item.status] ?? 'bg-gray-100 text-gray-600'
+                      }`}
+                    >
+                      {item.status.replace('_', ' ')}
+                    </span>
+                    <span className="text-sm font-semibold text-gray-900">{item.count}</span>
+                  </li>
+                ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Pending approvals callout */}
+      <Link
+        href="/director/approvals"
+        className="block bg-white rounded-xl border p-5 shadow-sm hover:shadow-md transition-shadow"
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="bg-amber-100 p-3 rounded-lg">
+              <CheckSquare size={22} className="text-amber-700" />
+            </div>
+            <div>
+              <p className="font-semibold text-gray-900">Pending Approvals</p>
+              <p className="text-sm text-gray-500 mt-0.5">Quotations awaiting your review</p>
+            </div>
+          </div>
+          <div className="text-right shrink-0">
+            {pendingApprovals.length > 0 ? (
+              <span className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-amber-500 text-white text-sm font-bold">
+                {pendingApprovals.length}
+              </span>
+            ) : (
+              <span className="text-sm text-gray-400">None</span>
+            )}
+          </div>
+        </div>
+      </Link>
+
+      {/* Future-phase placeholders */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Coming Soon</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <ComingSoon
+            module="Expense Approvals"
+            description="Review and approve company expense requests."
+          />
+          <ComingSoon
+            module="Contract Approvals"
+            description="Review and sign off on client contracts."
+          />
+          <ComingSoon
+            module="Client Onboarding Approvals"
+            description="Approve new client onboarding workflows."
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/director/page.tsx
+++ b/src/app/director/page.tsx
@@ -1,0 +1,16 @@
+import { ComingSoon } from '@/components/dashboard/ComingSoon';
+
+export default function DirectorPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Director Overview</h2>
+        <p className="text-sm text-gray-500 mt-1">Company-wide performance and strategic view.</p>
+      </div>
+      <ComingSoon
+        module="Director Dashboard"
+        description="Company-wide KPIs, financials, and team performance will be available here."
+      />
+    </div>
+  );
+}

--- a/src/app/director/reports/page.tsx
+++ b/src/app/director/reports/page.tsx
@@ -87,7 +87,7 @@ export default async function ReportsPage() {
                 {perf.technicianPerformance
                   .sort((a, b) => b.completedJobs - a.completedJobs)
                   .map((row) => (
-                    <tr key={row.name} className="hover:bg-gray-50">
+                    <tr key={row.technicianId} className="hover:bg-gray-50">
                       <td className="px-6 py-3 text-sm font-medium text-gray-900">{row.name}</td>
                       <td className="px-6 py-3 text-sm font-bold text-right text-[#009FCE]">{row.completedJobs}</td>
                     </tr>

--- a/src/app/director/reports/page.tsx
+++ b/src/app/director/reports/page.tsx
@@ -1,0 +1,102 @@
+import { getDepartmentPerformance } from '../actions';
+import { Award, TrendingUp, ShoppingCart } from 'lucide-react';
+
+export default async function ReportsPage() {
+  const perf = await getDepartmentPerformance();
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Department Performance</h2>
+        <p className="text-sm text-gray-500 mt-1">Read-only operational metrics</p>
+      </div>
+
+      {/* Top row: conversion rate + orders per month table */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {/* Conversion rate */}
+        <div className="bg-white rounded-xl border shadow-sm p-5">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="bg-[#009FCE]/10 p-2.5 rounded-lg">
+              <TrendingUp size={20} className="text-[#009FCE]" />
+            </div>
+            <p className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Conversion Rate</p>
+          </div>
+          <p className="text-4xl font-bold text-gray-900">{perf.conversionRate}%</p>
+          <p className="text-xs text-gray-500 mt-1">
+            {perf.converted} approved/converted of {perf.totalQuotations} total quotations
+          </p>
+        </div>
+
+        {/* Orders per month (last 6) */}
+        <div className="sm:col-span-2 bg-white rounded-xl border shadow-sm p-5">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="bg-indigo-100 p-2.5 rounded-lg">
+              <ShoppingCart size={20} className="text-indigo-600" />
+            </div>
+            <p className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Orders per Month</p>
+          </div>
+          {perf.ordersPerMonth.length === 0 ? (
+            <p className="text-sm text-gray-400 py-4 text-center">No order data yet</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="text-left py-2 pr-4 text-xs font-semibold uppercase tracking-wider text-gray-500">Month</th>
+                    <th className="text-right py-2 text-xs font-semibold uppercase tracking-wider text-gray-500">Orders</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {perf.ordersPerMonth.map((row) => (
+                    <tr key={row.month} className="hover:bg-slate-50">
+                      <td className="py-2 pr-4 text-gray-700">{row.month}</td>
+                      <td className="py-2 text-right font-semibold text-gray-900">{row.count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Technician completion table */}
+      <div className="bg-white rounded-xl border shadow-sm">
+        <div className="p-5 border-b flex items-center gap-3">
+          <div className="bg-teal-100 p-2.5 rounded-lg">
+            <Award size={20} className="text-teal-700" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-gray-900">Technician Completions</h3>
+            <p className="text-xs text-gray-500">Jobs completed or verified per technician</p>
+          </div>
+        </div>
+
+        {perf.technicianPerformance.length === 0 ? (
+          <div className="p-10 text-center text-sm text-gray-400">No completed jobs yet</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Technician</th>
+                  <th className="text-right px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Completed Jobs</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {perf.technicianPerformance
+                  .sort((a, b) => b.completedJobs - a.completedJobs)
+                  .map((row) => (
+                    <tr key={row.name} className="hover:bg-gray-50">
+                      <td className="px-6 py-3 text-sm font-medium text-gray-900">{row.name}</td>
+                      <td className="px-6 py-3 text-sm font-bold text-right text-[#009FCE]">{row.completedJobs}</td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/manager/actions.ts
+++ b/src/app/manager/actions.ts
@@ -5,7 +5,7 @@ import { clients } from '@/db/schema/clients';
 import { quotations } from '@/db/schema/quotations';
 import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
 import { requireRole } from '@/lib/auth';
-import { scopedCustomerIds, getJobs, getActiveAttendants, getThreads } from '@/lib/work';
+import { scopedCustomerIds, getJobs, getActiveTechnicians, getThreads } from '@/lib/work';
 
 // ── Overview ──────────────────────────────────────────────────────────────
 export async function getManagerData() {
@@ -54,16 +54,16 @@ export async function getManagerClients() {
 export async function getManagerJobsView() {
   const session = await requireRole(['manager']);
   const scope = await scopedCustomerIds(session);
-  const [jobs, attendants] = await Promise.all([getJobs(scope), getActiveAttendants()]);
+  const [jobs, attendants] = await Promise.all([getJobs(scope), getActiveTechnicians()]);
   const clientNameByUserId = await clientNameMap(session.user.id);
   return { jobs, attendants, clientNameByUserId };
 }
 
-// ── Team (attendants + progress) ───────────────────────────────────────────
+// ── Team (technicians + progress) ─────────────────────────────────────────
 export async function getManagerTeam() {
   const session = await requireRole(['manager']);
   const scope = await scopedCustomerIds(session);
-  const [attendants, jobs] = await Promise.all([getActiveAttendants(), getJobs(scope)]);
+  const [attendants, jobs] = await Promise.all([getActiveTechnicians(), getJobs(scope)]);
 
   return attendants.map((a) => {
     const theirs = jobs.filter((r) => r.job.assignedTo === a.id);

--- a/src/app/manager/actions.ts
+++ b/src/app/manager/actions.ts
@@ -9,7 +9,7 @@ import { scopedCustomerIds, getJobs, getActiveTechnicians, getThreads } from '@/
 
 // ── Overview ──────────────────────────────────────────────────────────────
 export async function getManagerData() {
-  const session = await requireRole(['manager']);
+  const session = await requireRole(['manager', 'super_admin']);
   const managerId = session.user.id;
 
   const assignedClients = await db
@@ -42,7 +42,7 @@ export async function getManagerData() {
 
 // ── Clients ───────────────────────────────────────────────────────────────
 export async function getManagerClients() {
-  const session = await requireRole(['manager']);
+  const session = await requireRole(['manager', 'super_admin']);
   return db
     .select()
     .from(clients)
@@ -52,7 +52,7 @@ export async function getManagerClients() {
 
 // ── Jobs ──────────────────────────────────────────────────────────────────
 export async function getManagerJobsView() {
-  const session = await requireRole(['manager']);
+  const session = await requireRole(['manager', 'super_admin']);
   const scope = await scopedCustomerIds(session);
   const [jobs, attendants] = await Promise.all([getJobs(scope), getActiveTechnicians()]);
   const clientNameByUserId = await clientNameMap(session.user.id);
@@ -61,7 +61,7 @@ export async function getManagerJobsView() {
 
 // ── Team (technicians + progress) ─────────────────────────────────────────
 export async function getManagerTeam() {
-  const session = await requireRole(['manager']);
+  const session = await requireRole(['manager', 'super_admin']);
   const scope = await scopedCustomerIds(session);
   const [attendants, jobs] = await Promise.all([getActiveTechnicians(), getJobs(scope)]);
 
@@ -79,7 +79,7 @@ export async function getManagerTeam() {
 
 // ── Messages ──────────────────────────────────────────────────────────────
 export async function getManagerMessagesView() {
-  const session = await requireRole(['manager']);
+  const session = await requireRole(['manager', 'super_admin']);
   const scope = await scopedCustomerIds(session);
   const threadsMap = await getThreads(scope);
   const clientNameByUserId = await clientNameMap(session.user.id);

--- a/src/app/manager/jobs/page.tsx
+++ b/src/app/manager/jobs/page.tsx
@@ -8,7 +8,7 @@ export default async function ManagerJobsPage() {
     <div className="space-y-6">
       <div>
         <h2 className="text-xl font-bold text-gray-900">Jobs &amp; Service Requests</h2>
-        <p className="text-sm text-gray-500 mt-1">Assign attendants, track progress, and verify completed work.</p>
+        <p className="text-sm text-gray-500 mt-1">Assign technicians, track progress, and verify completed work.</p>
       </div>
       <JobsBoard jobs={jobs} attendants={attendants} clientNameByUserId={clientNameByUserId} path="/manager/jobs" />
     </div>

--- a/src/app/manager/layout.tsx
+++ b/src/app/manager/layout.tsx
@@ -17,7 +17,7 @@ export default async function ManagerLayout({
   }
 
   const role = (session.user as { role?: string }).role;
-  if (role !== 'manager') {
+  if (role !== 'manager' && role !== 'super_admin') {
     redirect(homeForRole(role));
   }
 

--- a/src/app/manager/team/page.tsx
+++ b/src/app/manager/team/page.tsx
@@ -8,7 +8,7 @@ export default async function ManagerTeamPage() {
     <div className="space-y-6">
       <div>
         <h2 className="text-xl font-bold text-gray-900">Team Progress</h2>
-        <p className="text-sm text-gray-500 mt-1">Attendant workload across your assigned jobs.</p>
+        <p className="text-sm text-gray-500 mt-1">Technician workload across your assigned jobs.</p>
       </div>
       <TeamGrid team={team} />
     </div>

--- a/src/app/reception/actions.ts
+++ b/src/app/reception/actions.ts
@@ -1,0 +1,113 @@
+'use server';
+
+import { db } from '@/db';
+import { users } from '@/db/schema/auth';
+import { quotations } from '@/db/schema/quotations';
+import { messages } from '@/db/schema/messages';
+import { clients } from '@/db/schema/clients';
+import { count, eq, inArray, isNull, and, desc, ilike, or, sql } from 'drizzle-orm';
+import { requireRole } from '@/lib/auth';
+
+// ── Technician Availability ──────────────────────────────────────────────────
+// Returns active technicians with their active-job count (assigned or in_progress).
+// Sorted least-busy first. No staff email/phone — name + id only.
+export async function getTechnicianAvailability() {
+  await requireRole(['receptionist', 'super_admin']);
+
+  const activeJobCount = db
+    .select({ assignedTo: quotations.assignedTo, cnt: count().as('cnt') })
+    .from(quotations)
+    .where(
+      and(
+        isNull(quotations.deletedAt),
+        inArray(quotations.status as any, ['assigned', 'in_progress']),
+      ),
+    )
+    .groupBy(quotations.assignedTo)
+    .as('active_jobs');
+
+  const rows = await db
+    .select({
+      id: users.id,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      activeJobs: sql<number>`coalesce(${activeJobCount.cnt}, 0)`,
+    })
+    .from(users)
+    .leftJoin(activeJobCount, eq(users.id, activeJobCount.assignedTo))
+    .where(
+      and(
+        eq(users.role, 'technician'),
+        eq(users.isActive, true),
+        isNull(users.deletedAt),
+      ),
+    )
+    .orderBy(sql`coalesce(${activeJobCount.cnt}, 0)`, users.firstName);
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: `${r.firstName} ${r.lastName}`.trim(),
+    activeJobs: Number(r.activeJobs),
+  }));
+}
+
+// ── Recent Inbound Inquiries ─────────────────────────────────────────────────
+// Latest 10 inbound messages with sender name + snippet.
+export async function getRecentInquiries() {
+  await requireRole(['receptionist', 'super_admin']);
+
+  const rows = await db
+    .select({
+      id: messages.id,
+      subject: messages.subject,
+      content: messages.content,
+      createdAt: messages.createdAt,
+      senderFirstName: users.firstName,
+      senderLastName: users.lastName,
+    })
+    .from(messages)
+    .leftJoin(users, eq(messages.userId, users.id))
+    .where(eq(messages.direction, 'inbound'))
+    .orderBy(desc(messages.createdAt))
+    .limit(10);
+
+  return rows.map((r) => ({
+    id: r.id,
+    subject: r.subject,
+    snippet: r.content ? r.content.slice(0, 120) : '',
+    createdAt: r.createdAt,
+    senderName: r.senderFirstName
+      ? `${r.senderFirstName} ${r.senderLastName ?? ''}`.trim()
+      : 'Unknown',
+  }));
+}
+
+// ── Contact Directory ────────────────────────────────────────────────────────
+// Client contact info — NO financial joins, excludes soft-deleted.
+// Optional case-insensitive name or phone search.
+export async function getContactDirectory(query?: string) {
+  await requireRole(['receptionist', 'super_admin']);
+
+  const q = query?.trim();
+
+  const where = q
+    ? and(
+        isNull(clients.deletedAt),
+        or(ilike(clients.name, `%${q}%`), ilike(clients.phone, `%${q}%`)),
+      )
+    : isNull(clients.deletedAt);
+
+  return db
+    .select({
+      id: clients.id,
+      name: clients.name,
+      email: clients.email,
+      phone: clients.phone,
+      address: clients.address,
+      city: clients.city,
+      status: clients.status,
+    })
+    .from(clients)
+    .where(where)
+    .orderBy(clients.name);
+}

--- a/src/app/reception/actions.ts
+++ b/src/app/reception/actions.ts
@@ -89,11 +89,12 @@ export async function getContactDirectory(query?: string) {
   await requireRole(['receptionist', 'super_admin']);
 
   const q = query?.trim();
+  const escaped = q ? q.replace(/[\\%_]/g, (m) => '\\' + m) : undefined;
 
-  const where = q
+  const where = escaped
     ? and(
         isNull(clients.deletedAt),
-        or(ilike(clients.name, `%${q}%`), ilike(clients.phone, `%${q}%`)),
+        or(ilike(clients.name, `%${escaped}%`), ilike(clients.phone, `%${escaped}%`)),
       )
     : isNull(clients.deletedAt);
 

--- a/src/app/reception/contact-actions.ts
+++ b/src/app/reception/contact-actions.ts
@@ -1,0 +1,48 @@
+'use server';
+
+import { db } from '@/db';
+import { clients } from '@/db/schema/clients';
+import { eq, and, isNull } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_LEN = 200;
+
+function trimCap(val: FormDataEntryValue | null): string | undefined {
+  if (!val) return undefined;
+  const s = String(val).trim();
+  return s.length > 0 ? s.slice(0, MAX_LEN) : undefined;
+}
+
+// Receptionist may only update contact fields: phone, email, address, city.
+// Status and all other fields are intentionally excluded.
+export async function updateClientContact(formData: FormData) {
+  await requireRole(['receptionist', 'super_admin']);
+
+  const clientId = formData.get('clientId') as string;
+  if (!clientId || !UUID_RE.test(clientId)) throw new Error('Invalid client id');
+
+  const phone = trimCap(formData.get('phone'));
+  const email = trimCap(formData.get('email'));
+  const address = trimCap(formData.get('address'));
+  const city = trimCap(formData.get('city'));
+
+  const updated = await db
+    .update(clients)
+    .set({
+      ...(phone !== undefined && { phone }),
+      ...(email !== undefined && { email }),
+      ...(address !== undefined && { address }),
+      ...(city !== undefined && { city }),
+      updatedAt: new Date(),
+    })
+    .where(and(eq(clients.id, clientId), isNull(clients.deletedAt)))
+    .returning({ id: clients.id });
+
+  if (updated.length === 0) {
+    throw new Error('Client not found or has been deleted');
+  }
+
+  revalidatePath('/reception/contacts');
+}

--- a/src/app/reception/contact-actions.ts
+++ b/src/app/reception/contact-actions.ts
@@ -4,15 +4,15 @@ import { db } from '@/db';
 import { clients } from '@/db/schema/clients';
 import { eq, and, isNull } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
 import { requireRole } from '@/lib/auth';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MAX_LEN = 200;
 
-function trimCap(val: FormDataEntryValue | null): string | undefined {
+function trimCap(val: FormDataEntryValue | null, max = 200): string | undefined {
   if (!val) return undefined;
   const s = String(val).trim();
-  return s.length > 0 ? s.slice(0, MAX_LEN) : undefined;
+  return s.length > 0 ? s.slice(0, max) : undefined;
 }
 
 // Receptionist may only update contact fields: phone, email, address, city.
@@ -23,10 +23,10 @@ export async function updateClientContact(formData: FormData) {
   const clientId = formData.get('clientId') as string;
   if (!clientId || !UUID_RE.test(clientId)) throw new Error('Invalid client id');
 
-  const phone = trimCap(formData.get('phone'));
-  const email = trimCap(formData.get('email'));
-  const address = trimCap(formData.get('address'));
-  const city = trimCap(formData.get('city'));
+  const phone = trimCap(formData.get('phone'), 30);
+  const email = trimCap(formData.get('email'), 255);
+  const address = trimCap(formData.get('address'), 200);
+  const city = trimCap(formData.get('city'), 100);
 
   const updated = await db
     .update(clients)
@@ -45,4 +45,5 @@ export async function updateClientContact(formData: FormData) {
   }
 
   revalidatePath('/reception/contacts');
+  redirect('/reception/contacts');
 }

--- a/src/app/reception/contacts/page.tsx
+++ b/src/app/reception/contacts/page.tsx
@@ -1,0 +1,184 @@
+import { Search } from 'lucide-react';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
+import { getContactDirectory } from '../actions';
+import { updateClientContact } from '../contact-actions';
+
+function statusBadge(status: string) {
+  const map: Record<string, string> = {
+    active: 'bg-green-50 text-green-700',
+    lead: 'bg-blue-50 text-blue-700',
+    inactive: 'bg-gray-100 text-gray-500',
+  };
+  const labels: Record<string, string> = { active: 'Active', lead: 'Lead', inactive: 'Inactive' };
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${map[status] ?? 'bg-gray-100 text-gray-600'}`}>
+      {labels[status] ?? status}
+    </span>
+  );
+}
+
+type Props = {
+  searchParams: Promise<{ q?: string; edit?: string }>;
+};
+
+export default async function ReceptionContactsPage({ searchParams }: Props) {
+  const { q, edit } = await searchParams;
+  const contacts = await getContactDirectory(q);
+
+  const editingId = edit ?? null;
+  const editingContact = editingId ? contacts.find((c) => c.id === editingId) : null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header + search */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Contacts</h2>
+          <p className="text-sm text-gray-500 mt-1">
+            {contacts.length} client{contacts.length !== 1 ? 's' : ''}
+            {q ? ` matching "${q}"` : ''}
+          </p>
+        </div>
+        <form method="GET" action="/reception/contacts" className="flex gap-2">
+          <div className="relative">
+            <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
+            <input
+              name="q"
+              type="search"
+              defaultValue={q ?? ''}
+              placeholder="Name or phone…"
+              className="rounded-lg border border-gray-200 bg-gray-50 pl-8 pr-3 py-2 text-sm w-48 focus:outline-none focus:ring-2 focus:ring-[#009FCE] focus:border-transparent"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-lg bg-[#009FCE] px-3 py-2 text-sm font-medium text-white hover:bg-[#007fa8] transition-colors"
+          >
+            Search
+          </button>
+          {q && (
+            <a href="/reception/contacts" className="rounded-lg border px-3 py-2 text-sm text-gray-500 hover:bg-gray-50 transition-colors">
+              Clear
+            </a>
+          )}
+        </form>
+      </div>
+
+      {/* Inline edit panel — rendered when ?edit=<id> */}
+      {editingContact && (
+        <div className="bg-[#EFF8FB] border border-[#009FCE]/30 rounded-xl p-5">
+          <h3 className="text-sm font-semibold text-[#00477A] mb-4">
+            Edit contact info — {editingContact.name}
+          </h3>
+          <form action={updateClientContact}>
+            <input type="hidden" name="clientId" value={editingContact.id} />
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Phone</label>
+                <input
+                  name="phone"
+                  type="tel"
+                  defaultValue={editingContact.phone ?? ''}
+                  maxLength={30}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Email</label>
+                <input
+                  name="email"
+                  type="email"
+                  defaultValue={editingContact.email ?? ''}
+                  maxLength={200}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">City</label>
+                <input
+                  name="city"
+                  type="text"
+                  defaultValue={editingContact.city ?? ''}
+                  maxLength={100}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Address</label>
+                <input
+                  name="address"
+                  type="text"
+                  defaultValue={editingContact.address ?? ''}
+                  maxLength={200}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+                />
+              </div>
+            </div>
+            <div className="mt-4 flex gap-2">
+              <SubmitButton
+                label="Save changes"
+                pendingLabel="Saving…"
+                className="rounded-lg bg-[#00477A] px-4 py-2 text-sm font-medium text-white hover:bg-[#003a63] transition-colors disabled:opacity-60"
+              />
+              <a
+                href={`/reception/contacts${q ? `?q=${encodeURIComponent(q)}` : ''}`}
+                className="rounded-lg border px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </a>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Directory table */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        {contacts.length === 0 ? (
+          <div className="p-16 text-center text-sm text-gray-400">
+            {q ? `No clients found matching "${q}"` : 'No clients on record yet'}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Name</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Phone</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Email</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">City</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Status</th>
+                  <th className="px-6 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {contacts.map((c) => {
+                  const isEditing = c.id === editingId;
+                  const editHref = isEditing
+                    ? `/reception/contacts${q ? `?q=${encodeURIComponent(q)}` : ''}`
+                    : `/reception/contacts?edit=${c.id}${q ? `&q=${encodeURIComponent(q)}` : ''}`;
+                  return (
+                    <tr key={c.id} className={isEditing ? 'bg-[#EFF8FB]' : 'hover:bg-gray-50'}>
+                      <td className="px-6 py-3 text-sm font-medium text-gray-900">{c.name}</td>
+                      <td className="px-6 py-3 text-sm text-gray-600">{c.phone ?? '—'}</td>
+                      <td className="px-6 py-3 text-sm text-gray-600">{c.email ?? '—'}</td>
+                      <td className="px-6 py-3 text-sm text-gray-600">{c.city ?? '—'}</td>
+                      <td className="px-6 py-3">{statusBadge(c.status)}</td>
+                      <td className="px-6 py-3 text-right">
+                        <a
+                          href={editHref}
+                          className="text-xs font-medium text-[#009FCE] hover:underline"
+                        >
+                          {isEditing ? 'Close' : 'Edit'}
+                        </a>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/reception/layout.tsx
+++ b/src/app/reception/layout.tsx
@@ -1,6 +1,10 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getSession } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { auth, getSession } from '@/lib/auth';
 import { homeForRole } from '@/lib/roles';
+import { ReceptionNav } from '@/components/dashboard/ReceptionNav';
+import { LogOut, Globe } from 'lucide-react';
 
 export default async function ReceptionLayout({
   children,
@@ -13,18 +17,56 @@ export default async function ReceptionLayout({
   }
 
   const role = (session.user as { role?: string }).role;
-  if (role !== 'receptionist') {
+  if (role !== 'receptionist' && role !== 'super_admin') {
     redirect(homeForRole(role));
   }
+
+  const initial = session.user.name?.[0]?.toUpperCase() ?? 'R';
 
   return (
     <div className="min-h-dvh bg-slate-50">
       <header className="bg-[#00477A] text-white">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
-          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Reception Dashboard</p>
-          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Reception</p>
+            <h1 className="text-xl font-bold mt-0.5 truncate">{session.user.name}</h1>
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+            >
+              <Globe size={16} />
+              <span className="hidden sm:inline">Website</span>
+            </Link>
+            <div className="hidden sm:flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-sm font-bold">
+              {initial}
+            </div>
+            <form
+              action={async () => {
+                'use server';
+                await auth.api.signOut({ headers: await headers() });
+                redirect('/auth/login');
+              }}
+            >
+              <button
+                type="submit"
+                className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+              >
+                <LogOut size={16} />
+                <span className="hidden sm:inline">Sign Out</span>
+              </button>
+            </form>
+          </div>
         </div>
       </header>
+
+      <div className="bg-white border-b sticky top-0 z-10">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <ReceptionNav />
+        </div>
+      </div>
+
       <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
     </div>
   );

--- a/src/app/reception/layout.tsx
+++ b/src/app/reception/layout.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth';
+import { homeForRole } from '@/lib/roles';
+
+export default async function ReceptionLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+  if (!session?.user) {
+    redirect('/auth/login');
+  }
+
+  const role = (session.user as { role?: string }).role;
+  if (role !== 'receptionist') {
+    redirect(homeForRole(role));
+  }
+
+  return (
+    <div className="min-h-dvh bg-slate-50">
+      <header className="bg-[#00477A] text-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Reception Dashboard</p>
+          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/reception/page.tsx
+++ b/src/app/reception/page.tsx
@@ -1,16 +1,142 @@
+import Link from 'next/link';
+import { Search } from 'lucide-react';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
+import { getTechnicianAvailability, getRecentInquiries } from './actions';
 
-export default function ReceptionPage() {
+function availabilityBadge(activeJobs: number) {
+  if (activeJobs === 0) {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700">
+        Available
+      </span>
+    );
+  }
   return (
-    <div className="space-y-6">
+    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
+      Busy
+    </span>
+  );
+}
+
+function formatTime(date: Date | string | null) {
+  if (!date) return '';
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toLocaleTimeString('en-UG', {
+    timeZone: 'Africa/Kampala',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default async function ReceptionTodayPage() {
+  const [technicians, inquiries] = await Promise.all([
+    getTechnicianAvailability(),
+    getRecentInquiries(),
+  ]);
+
+  return (
+    <div className="space-y-8">
+      {/* Page title */}
       <div>
-        <h2 className="text-2xl font-bold text-gray-900">Reception Overview</h2>
-        <p className="text-sm text-gray-500 mt-1">Appointments, enquiries, and front-desk operations.</p>
+        <h2 className="text-2xl font-bold text-gray-900">Today</h2>
+        <p className="text-sm text-gray-500 mt-1">Front-desk overview — technician status, recent inquiries, and quick contact lookup.</p>
       </div>
-      <ComingSoon
-        module="Reception Dashboard"
-        description="Appointment scheduling, customer enquiries, and front-desk tools will be available here."
-      />
+
+      {/* Quick contact search */}
+      <div className="bg-white rounded-xl border shadow-sm p-5">
+        <h3 className="text-sm font-semibold text-gray-700 mb-3">Quick Contact Search</h3>
+        <form method="GET" action="/reception/contacts" className="flex gap-2">
+          <div className="relative flex-1">
+            <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
+            <input
+              name="q"
+              type="search"
+              placeholder="Search client name or phone…"
+              className="w-full rounded-lg border border-gray-200 bg-gray-50 pl-9 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#009FCE] focus:border-transparent"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-lg bg-[#009FCE] px-4 py-2 text-sm font-medium text-white hover:bg-[#007fa8] transition-colors focus:outline-none focus:ring-2 focus:ring-[#009FCE]"
+          >
+            Search
+          </button>
+        </form>
+      </div>
+
+      {/* Technician availability grid */}
+      <div>
+        <h3 className="text-base font-semibold text-gray-800 mb-3">
+          Technician Availability
+          <span className="ml-2 text-sm font-normal text-gray-400">({technicians.length})</span>
+        </h3>
+        {technicians.length === 0 ? (
+          <div className="bg-white rounded-xl border shadow-sm p-10 text-center text-sm text-gray-400">
+            No active technicians on record
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {technicians.map((tech) => (
+              <div key={tech.id} className="bg-white rounded-xl border shadow-sm p-4 flex flex-col gap-2">
+                <p className="text-sm font-semibold text-gray-900 truncate">{tech.name}</p>
+                <div className="flex items-center justify-between gap-2">
+                  {availabilityBadge(tech.activeJobs)}
+                  <span className="text-xs text-gray-400">
+                    {tech.activeJobs} job{tech.activeJobs !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Recent inquiries */}
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-base font-semibold text-gray-800">Recent Inquiries</h3>
+        </div>
+        {inquiries.length === 0 ? (
+          <div className="bg-white rounded-xl border shadow-sm p-10 text-center text-sm text-gray-400">
+            No inbound inquiries yet
+          </div>
+        ) : (
+          <div className="bg-white rounded-xl border shadow-sm divide-y">
+            {inquiries.map((inq) => (
+              <div key={inq.id} className="px-5 py-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-gray-900 truncate">{inq.senderName}</p>
+                    <p className="text-xs font-medium text-gray-600 mt-0.5 truncate">{inq.subject}</p>
+                    {inq.snippet && (
+                      <p className="text-xs text-gray-500 mt-1 line-clamp-2">{inq.snippet}</p>
+                    )}
+                  </div>
+                  <span className="text-xs text-gray-400 whitespace-nowrap shrink-0">
+                    {formatTime(inq.createdAt)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Coming soon modules */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <ComingSoon
+          module="Appointments Calendar"
+          description="Schedule and track client appointments directly from the front desk."
+        />
+        <ComingSoon
+          module="Visitor Log"
+          description="Record walk-in visitors and on-site guest activity."
+        />
+        <ComingSoon
+          module="Call Log"
+          description="Track inbound and outbound calls with notes and follow-ups."
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/reception/page.tsx
+++ b/src/app/reception/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { Search } from 'lucide-react';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
 import { getTechnicianAvailability, getRecentInquiries } from './actions';

--- a/src/app/reception/page.tsx
+++ b/src/app/reception/page.tsx
@@ -1,0 +1,16 @@
+import { ComingSoon } from '@/components/dashboard/ComingSoon';
+
+export default function ReceptionPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Reception Overview</h2>
+        <p className="text-sm text-gray-500 mt-1">Appointments, enquiries, and front-desk operations.</p>
+      </div>
+      <ComingSoon
+        module="Reception Dashboard"
+        description="Appointment scheduling, customer enquiries, and front-desk tools will be available here."
+      />
+    </div>
+  );
+}

--- a/src/app/sales/actions.ts
+++ b/src/app/sales/actions.ts
@@ -1,0 +1,125 @@
+'use server';
+
+import { db } from '@/db';
+import { clients } from '@/db/schema/clients';
+import { quotations } from '@/db/schema/quotations';
+import { payments } from '@/db/schema/payments';
+import { count, eq, inArray, isNull, sum, and, desc, gte, sql } from 'drizzle-orm';
+import { requireRole } from '@/lib/auth';
+
+const APPROVAL_STATUSES = ['pending', 'reviewed', 'approved', 'rejected', 'converted'] as const;
+
+// ── Sales Overview ──────────────────────────────────────────────────────────
+export async function getSalesOverview() {
+  await requireRole(['sales_manager', 'super_admin']);
+
+  const sixMonthsAgo = new Date();
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+  sixMonthsAgo.setDate(1);
+  sixMonthsAgo.setHours(0, 0, 0, 0);
+
+  const [pipelineCounts, leadsRow, monthlyRevenue] = await Promise.all([
+    // Pipeline counts for approval statuses only
+    db
+      .select({ status: quotations.status, value: count() })
+      .from(quotations)
+      .where(
+        and(
+          isNull(quotations.deletedAt),
+          inArray(quotations.status as any, [...APPROVAL_STATUSES]),
+        ),
+      )
+      .groupBy(quotations.status),
+
+    // Leads count
+    db
+      .select({ value: count() })
+      .from(clients)
+      .where(and(isNull(clients.deletedAt), eq(clients.status, 'lead')))
+      .then((rows) => rows[0]),
+
+    // Monthly revenue last 6 months (read-only)
+    db
+      .select({
+        month: sql<string>`to_char(${payments.createdAt}, 'Mon YYYY')`,
+        monthSort: sql<string>`to_char(${payments.createdAt}, 'YYYY-MM')`,
+        total: sum(payments.amount),
+      })
+      .from(payments)
+      .where(and(eq(payments.status, 'completed'), gte(payments.createdAt, sixMonthsAgo)))
+      .groupBy(
+        sql`to_char(${payments.createdAt}, 'Mon YYYY')`,
+        sql`to_char(${payments.createdAt}, 'YYYY-MM')`,
+      )
+      .orderBy(sql`to_char(${payments.createdAt}, 'YYYY-MM')`),
+  ]);
+
+  // Build pipeline map
+  const byStatus: Record<string, number> = {};
+  for (const r of pipelineCounts) {
+    byStatus[r.status ?? ''] = Number(r.value);
+  }
+
+  const pending = byStatus['pending'] ?? 0;
+  const reviewed = byStatus['reviewed'] ?? 0;
+  const approved = byStatus['approved'] ?? 0;
+  const rejected = byStatus['rejected'] ?? 0;
+  const converted = byStatus['converted'] ?? 0;
+  const total = pending + reviewed + approved + rejected + converted;
+  const conversionRate = total > 0 ? Math.round(((approved + converted) / total) * 100) : 0;
+
+  return {
+    pipeline: { pending, reviewed, approved, rejected, converted },
+    conversionRate,
+    totalPipelineQuotations: total,
+    leadsCount: Number(leadsRow?.value ?? 0),
+    monthlyRevenue: monthlyRevenue.map((r) => ({
+      month: r.month,
+      total: Number(r.total ?? 0),
+    })),
+  };
+}
+
+// ── Leads ───────────────────────────────────────────────────────────────────
+export async function getLeads() {
+  await requireRole(['sales_manager', 'super_admin']);
+
+  const rows = await db
+    .select({
+      id: clients.id,
+      name: clients.name,
+      email: clients.email,
+      phone: clients.phone,
+      city: clients.city,
+      createdAt: clients.createdAt,
+    })
+    .from(clients)
+    .where(and(isNull(clients.deletedAt), eq(clients.status, 'lead')))
+    .orderBy(desc(clients.createdAt));
+
+  return rows;
+}
+
+// ── Recent Quotations ────────────────────────────────────────────────────────
+export async function getRecentQuotations() {
+  await requireRole(['sales_manager', 'super_admin']);
+
+  const rows = await db
+    .select({
+      id: quotations.id,
+      quotationNumber: quotations.quotationNumber,
+      customerName: quotations.customerName,
+      status: quotations.status,
+      totalAmount: quotations.totalAmount,
+      createdAt: quotations.createdAt,
+    })
+    .from(quotations)
+    .where(isNull(quotations.deletedAt))
+    .orderBy(desc(quotations.createdAt))
+    .limit(10);
+
+  return rows.map((r) => ({
+    ...r,
+    totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
+  }));
+}

--- a/src/app/sales/actions.ts
+++ b/src/app/sales/actions.ts
@@ -66,6 +66,7 @@ export async function getSalesOverview() {
   const rejected = byStatus['rejected'] ?? 0;
   const converted = byStatus['converted'] ?? 0;
   const total = pending + reviewed + approved + rejected + converted;
+  // Denominator: approval-workflow statuses only — intentionally excludes job-lifecycle rows (director reports use all quotations)
   const conversionRate = total > 0 ? Math.round(((approved + converted) / total) * 100) : 0;
 
   return {
@@ -114,7 +115,7 @@ export async function getRecentQuotations() {
       createdAt: quotations.createdAt,
     })
     .from(quotations)
-    .where(isNull(quotations.deletedAt))
+    .where(and(isNull(quotations.deletedAt), inArray(quotations.status as any, [...APPROVAL_STATUSES])))
     .orderBy(desc(quotations.createdAt))
     .limit(10);
 

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth';
+import { homeForRole } from '@/lib/roles';
+
+export default async function SalesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+  if (!session?.user) {
+    redirect('/auth/login');
+  }
+
+  const role = (session.user as { role?: string }).role;
+  if (role !== 'sales_manager') {
+    redirect(homeForRole(role));
+  }
+
+  return (
+    <div className="min-h-dvh bg-slate-50">
+      <header className="bg-[#00477A] text-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Sales Dashboard</p>
+          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -1,6 +1,10 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getSession } from '@/lib/auth';
+import { headers } from 'next/headers';
+import { auth, getSession } from '@/lib/auth';
 import { homeForRole } from '@/lib/roles';
+import { SalesNav } from '@/components/dashboard/SalesNav';
+import { LogOut, Globe } from 'lucide-react';
 
 export default async function SalesLayout({
   children,
@@ -13,18 +17,56 @@ export default async function SalesLayout({
   }
 
   const role = (session.user as { role?: string }).role;
-  if (role !== 'sales_manager') {
+  if (role !== 'sales_manager' && role !== 'super_admin') {
     redirect(homeForRole(role));
   }
+
+  const initial = session.user.name?.[0]?.toUpperCase() ?? 'S';
 
   return (
     <div className="min-h-dvh bg-slate-50">
       <header className="bg-[#00477A] text-white">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5">
-          <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Sales Dashboard</p>
-          <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Sales Dashboard</p>
+            <h1 className="text-xl font-bold mt-0.5 truncate">{session.user.name}</h1>
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+            >
+              <Globe size={16} />
+              <span className="hidden sm:inline">Website</span>
+            </Link>
+            <div className="hidden sm:flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-sm font-bold">
+              {initial}
+            </div>
+            <form
+              action={async () => {
+                'use server';
+                await auth.api.signOut({ headers: await headers() });
+                redirect('/auth/login');
+              }}
+            >
+              <button
+                type="submit"
+                className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+              >
+                <LogOut size={16} />
+                <span className="hidden sm:inline">Sign Out</span>
+              </button>
+            </form>
+          </div>
         </div>
       </header>
+
+      <div className="bg-white border-b sticky top-0 z-10">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <SalesNav />
+        </div>
+      </div>
+
       <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
     </div>
   );

--- a/src/app/sales/lead-actions.ts
+++ b/src/app/sales/lead-actions.ts
@@ -2,7 +2,7 @@
 
 import { db } from '@/db';
 import { clients } from '@/db/schema/clients';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, isNull } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
 
@@ -25,7 +25,7 @@ export async function updateLeadStatus(formData: FormData) {
   const updated = await db
     .update(clients)
     .set({ status: newStatus, updatedAt: new Date() })
-    .where(and(eq(clients.id, leadId), eq(clients.status, 'lead')))
+    .where(and(eq(clients.id, leadId), eq(clients.status, 'lead'), isNull(clients.deletedAt)))
     .returning({ id: clients.id });
 
   if (updated.length === 0) {

--- a/src/app/sales/lead-actions.ts
+++ b/src/app/sales/lead-actions.ts
@@ -1,0 +1,37 @@
+'use server';
+
+import { db } from '@/db';
+import { clients } from '@/db/schema/clients';
+import { eq, and } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ALLOWED_STATUSES = ['active', 'inactive'] as const;
+type AllowedStatus = (typeof ALLOWED_STATUSES)[number];
+
+export async function updateLeadStatus(formData: FormData) {
+  await requireRole(['sales_manager', 'super_admin']);
+
+  const leadId = formData.get('leadId') as string;
+  const newStatus = formData.get('newStatus') as string;
+
+  if (!leadId || !UUID_RE.test(leadId)) throw new Error('Invalid lead id');
+  if (!ALLOWED_STATUSES.includes(newStatus as AllowedStatus)) {
+    throw new Error('Invalid status');
+  }
+
+  const updated = await db
+    .update(clients)
+    .set({ status: newStatus, updatedAt: new Date() })
+    .where(and(eq(clients.id, leadId), eq(clients.status, 'lead')))
+    .returning({ id: clients.id });
+
+  if (updated.length === 0) {
+    throw new Error('Lead already converted or not found');
+  }
+
+  revalidatePath('/sales/leads');
+  revalidatePath('/sales');
+}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -1,0 +1,82 @@
+import { getLeads } from '../actions';
+import { updateLeadStatus } from '../lead-actions';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
+import { Users } from 'lucide-react';
+
+export default async function LeadsPage() {
+  const leads = await getLeads();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Leads</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Prospective clients — mark won to convert to active, or lost to close.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        {leads.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+            <Users size={40} className="text-slate-300" />
+            <p className="text-base font-medium text-slate-500">No leads yet</p>
+            <p className="text-sm text-slate-400">New leads will appear here when clients are added with status &quot;lead&quot;.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Name</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Contact</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">City</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Created</th>
+                  <th className="text-right px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {leads.map((lead) => (
+                  <tr key={lead.id} className="hover:bg-slate-50 transition-colors">
+                    <td className="px-6 py-4 font-medium text-slate-900">{lead.name}</td>
+                    <td className="px-6 py-4 text-slate-600">
+                      <div>{lead.email ?? '—'}</div>
+                      {lead.phone && <div className="text-xs text-slate-400">{lead.phone}</div>}
+                    </td>
+                    <td className="px-6 py-4 text-slate-600">{lead.city ?? '—'}</td>
+                    <td className="px-6 py-4 text-slate-500">
+                      {lead.createdAt ? new Date(lead.createdAt).toLocaleDateString('en-UG') : '—'}
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex items-center justify-end gap-2">
+                        {/* Mark Won → active */}
+                        <form action={updateLeadStatus}>
+                          <input type="hidden" name="leadId" value={lead.id} />
+                          <input type="hidden" name="newStatus" value="active" />
+                          <SubmitButton
+                            label="Mark Won"
+                            pendingLabel="Saving…"
+                            className="inline-flex items-center rounded-lg bg-green-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-green-700 disabled:opacity-50 transition-colors"
+                          />
+                        </form>
+                        {/* Mark Lost → inactive */}
+                        <form action={updateLeadStatus}>
+                          <input type="hidden" name="leadId" value={lead.id} />
+                          <input type="hidden" name="newStatus" value="inactive" />
+                          <SubmitButton
+                            label="Mark Lost"
+                            pendingLabel="Saving…"
+                            className="inline-flex items-center rounded-lg bg-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-300 disabled:opacity-50 transition-colors"
+                          />
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -1,0 +1,16 @@
+import { ComingSoon } from '@/components/dashboard/ComingSoon';
+
+export default function SalesPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Sales Overview</h2>
+        <p className="text-sm text-gray-500 mt-1">Leads, pipeline, and revenue tracking.</p>
+      </div>
+      <ComingSoon
+        module="Sales Dashboard"
+        description="Lead management, pipeline tracking, and revenue metrics will be available here."
+      />
+    </div>
+  );
+}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -1,15 +1,175 @@
+import Link from 'next/link';
+import { getSalesOverview, getRecentQuotations } from './actions';
+import { RevenueChart } from '@/components/dashboard/RevenueChart';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
+import { TrendingUp, Users, CheckCircle, XCircle, Clock, Eye, RefreshCw } from 'lucide-react';
 
-export default function SalesPage() {
+function StatCard({
+  label,
+  value,
+  sub,
+  icon: Icon,
+  accent,
+  href,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  icon: React.ElementType;
+  accent: string;
+  href?: string;
+}) {
+  const inner = (
+    <div className="bg-white rounded-xl border shadow-sm p-5 flex items-start gap-4 hover:shadow-md transition-shadow">
+      <div className={`p-2.5 rounded-lg ${accent}`}>
+        <Icon size={20} className="text-white" />
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">{label}</p>
+        <p className="text-2xl font-bold text-slate-900 mt-0.5">{value}</p>
+        {sub && <p className="text-xs text-slate-400 mt-0.5">{sub}</p>}
+      </div>
+    </div>
+  );
+
+  if (href) {
+    return <Link href={href} className="block">{inner}</Link>;
+  }
+  return inner;
+}
+
+function statusLabel(status: string | null): string {
+  switch (status) {
+    case 'pending': return 'Pending';
+    case 'reviewed': return 'Reviewed';
+    case 'approved': return 'Approved';
+    case 'rejected': return 'Rejected';
+    case 'converted': return 'Converted';
+    case 'assigned': return 'Assigned';
+    case 'in_progress': return 'In Progress';
+    case 'completed': return 'Completed';
+    case 'verified': return 'Verified';
+    case 'cancelled': return 'Cancelled';
+    default: return status ?? '—';
+  }
+}
+
+function statusBadgeClass(status: string | null): string {
+  switch (status) {
+    case 'pending': return 'bg-amber-100 text-amber-800';
+    case 'reviewed': return 'bg-blue-100 text-blue-800';
+    case 'approved': return 'bg-green-100 text-green-800';
+    case 'rejected': return 'bg-red-100 text-red-800';
+    case 'converted': return 'bg-[#009FCE]/15 text-[#00477A]';
+    default: return 'bg-slate-100 text-slate-700';
+  }
+}
+
+export default async function SalesPage() {
+  const [overview, recentQuotations] = await Promise.all([
+    getSalesOverview(),
+    getRecentQuotations(),
+  ]);
+
+  const { pipeline, conversionRate, leadsCount, monthlyRevenue } = overview;
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
+      {/* Page title */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900">Sales Overview</h2>
-        <p className="text-sm text-gray-500 mt-1">Leads, pipeline, and revenue tracking.</p>
+        <p className="text-sm text-gray-500 mt-1">Pipeline, leads, and revenue at a glance.</p>
       </div>
+
+      {/* Pipeline stage cards */}
+      <section>
+        <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">Pipeline Stages</h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <StatCard label="Pending" value={pipeline.pending} icon={Clock} accent="bg-amber-500" />
+          <StatCard label="Reviewed" value={pipeline.reviewed} icon={Eye} accent="bg-blue-500" />
+          <StatCard label="Approved" value={pipeline.approved} icon={CheckCircle} accent="bg-green-600" />
+          <StatCard label="Converted" value={pipeline.converted} icon={RefreshCw} accent="bg-[#009FCE]" />
+          <StatCard label="Rejected" value={pipeline.rejected} icon={XCircle} accent="bg-red-500" />
+        </div>
+      </section>
+
+      {/* KPI row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <StatCard
+          label="Conversion Rate"
+          value={`${conversionRate}%`}
+          sub="(approved + converted) / all approval statuses"
+          icon={TrendingUp}
+          accent="bg-[#00477A]"
+        />
+        <StatCard
+          label="Active Leads"
+          value={leadsCount}
+          sub="Click to manage leads"
+          icon={Users}
+          accent="bg-[#009FCE]"
+          href="/sales/leads"
+        />
+      </div>
+
+      {/* Monthly revenue chart */}
+      <section className="bg-white rounded-xl border shadow-sm p-6">
+        <h3 className="text-sm font-semibold text-slate-700 mb-4">Monthly Revenue (last 6 months)</h3>
+        {monthlyRevenue.length > 0 ? (
+          <RevenueChart data={monthlyRevenue} />
+        ) : (
+          <p className="text-sm text-slate-400 py-8 text-center">No completed payments in the last 6 months.</p>
+        )}
+        <p className="text-xs text-slate-400 mt-3">Read-only view from completed payments.</p>
+      </section>
+
+      {/* Recent Quotations */}
+      <section className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b">
+          <h3 className="text-sm font-semibold text-slate-700">Recent Quotations</h3>
+        </div>
+        {recentQuotations.length === 0 ? (
+          <p className="text-sm text-slate-400 px-6 py-8 text-center">No quotations yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Number</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Customer</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Status</th>
+                  <th className="text-right px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Amount</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Date</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {recentQuotations.map((q) => (
+                  <tr key={q.id} className="hover:bg-slate-50 transition-colors">
+                    <td className="px-6 py-3 font-mono text-slate-700">{q.quotationNumber}</td>
+                    <td className="px-6 py-3 text-slate-900">{q.customerName}</td>
+                    <td className="px-6 py-3">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusBadgeClass(q.status)}`}>
+                        {statusLabel(q.status)}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-right text-slate-700">
+                      {q.totalAmount != null ? `UGX ${q.totalAmount.toLocaleString('en-UG')}` : '—'}
+                    </td>
+                    <td className="px-6 py-3 text-slate-500">
+                      {q.createdAt ? new Date(q.createdAt).toLocaleDateString('en-UG') : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Coming soon */}
       <ComingSoon
-        module="Sales Dashboard"
-        description="Lead management, pipeline tracking, and revenue metrics will be available here."
+        module="Pipeline stages & lead sources"
+        description="Visual pipeline board and lead source attribution will be available in a later phase."
       />
     </div>
   );

--- a/src/app/technician/actions.ts
+++ b/src/app/technician/actions.ts
@@ -5,9 +5,9 @@ import { quotations } from '@/db/schema/quotations';
 import { and, desc, eq, isNull } from 'drizzle-orm';
 import { requireRole } from '@/lib/auth';
 
-// Jobs assigned to this attendant (quotations.assignedTo).
-export async function getAttendantData() {
-  const session = await requireRole(['attendant']);
+// Jobs assigned to this technician (quotations.assignedTo).
+export async function getTechnicianData() {
+  const session = await requireRole(['technician']);
 
   const jobs = await db
     .select()

--- a/src/app/technician/actions.ts
+++ b/src/app/technician/actions.ts
@@ -2,24 +2,102 @@
 
 import { db } from '@/db';
 import { quotations } from '@/db/schema/quotations';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { clients } from '@/db/schema/clients';
+import { and, asc, eq, gte, inArray, isNull } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
 
-// Jobs assigned to this technician (quotations.assignedTo).
-export async function getTechnicianData() {
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Safe columns — NO money columns (no totalAmount, no estimatedBudget).
+const SAFE_COLS = {
+  id: quotations.id,
+  quotationNumber: quotations.quotationNumber,
+  customerName: quotations.customerName,
+  projectDescription: quotations.projectDescription,
+  location: quotations.location,
+  status: quotations.status,
+  createdAt: quotations.createdAt,
+  updatedAt: quotations.updatedAt,
+  // Client contact info (from LEFT JOIN)
+  clientPhone: clients.phone,
+  clientAddress: clients.address,
+  clientCity: clients.city,
+};
+
+// Active work queue: assigned or in-progress jobs for this technician, oldest first.
+export async function getMyJobs() {
   const session = await requireRole(['technician']);
 
-  const jobs = await db
-    .select()
+  return db
+    .select(SAFE_COLS)
     .from(quotations)
-    .where(and(eq(quotations.assignedTo, session.user.id), isNull(quotations.deletedAt)))
-    .orderBy(desc(quotations.createdAt));
+    .leftJoin(clients, eq(quotations.customerId, clients.userId))
+    .where(
+      and(
+        eq(quotations.assignedTo, session.user.id),
+        inArray(quotations.status as any, ['assigned', 'in_progress']),
+        isNull(quotations.deletedAt),
+      ),
+    )
+    .orderBy(asc(quotations.createdAt));
+}
 
-  return {
-    jobs,
-    stats: {
-      pending: jobs.filter((j) => j.status === 'pending' || j.status === 'in_progress').length,
-      completed: jobs.filter((j) => j.status === 'completed').length,
-    },
-  };
+// Jobs completed or verified by this technician today.
+export async function getMyCompletedToday() {
+  const session = await requireRole(['technician']);
+
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+
+  return db
+    .select(SAFE_COLS)
+    .from(quotations)
+    .leftJoin(clients, eq(quotations.customerId, clients.userId))
+    .where(
+      and(
+        eq(quotations.assignedTo, session.user.id),
+        inArray(quotations.status as any, ['completed', 'verified']),
+        gte(quotations.updatedAt, todayStart),
+        isNull(quotations.deletedAt),
+      ),
+    )
+    .orderBy(asc(quotations.updatedAt));
+}
+
+// Allowed transitions for technicians only.
+const ALLOWED_TRANSITIONS: Record<string, string> = {
+  assigned: 'in_progress',
+  in_progress: 'completed',
+};
+
+// Advance a job's status. Only the assigned technician can move their own jobs.
+export async function updateMyJobStatus(formData: FormData) {
+  const session = await requireRole(['technician']);
+
+  const jobId = formData.get('jobId') as string;
+  const currentStatus = formData.get('currentStatus') as string;
+
+  if (!jobId || !UUID_RE.test(jobId)) throw new Error('Invalid job id');
+
+  const nextStatus = ALLOWED_TRANSITIONS[currentStatus];
+  if (!nextStatus) throw new Error('Transition not allowed');
+
+  const updated = await db
+    .update(quotations)
+    .set({ status: nextStatus, updatedAt: new Date() })
+    .where(
+      and(
+        eq(quotations.id, jobId),
+        eq(quotations.assignedTo, session.user.id),
+        eq(quotations.status as any, currentStatus),
+      ),
+    )
+    .returning({ id: quotations.id });
+
+  if (updated.length === 0) {
+    throw new Error('Job not found or status has changed — please refresh.');
+  }
+
+  revalidatePath('/technician');
 }

--- a/src/app/technician/actions.ts
+++ b/src/app/technician/actions.ts
@@ -47,8 +47,9 @@ export async function getMyJobs() {
 export async function getMyCompletedToday() {
   const session = await requireRole(['technician']);
 
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
+  const todayStart = new Date(
+    new Intl.DateTimeFormat('en-CA', { timeZone: 'Africa/Kampala' }).format(new Date()) + 'T00:00:00+03:00'
+  );
 
   return db
     .select(SAFE_COLS)

--- a/src/app/technician/layout.tsx
+++ b/src/app/technician/layout.tsx
@@ -27,8 +27,10 @@ export default async function TechnicianLayout({
       <header className="bg-[#00477A] text-white">
         <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
           <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Technician Dashboard</p>
-            <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
+            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Technician</p>
+            <h1 className="text-xl font-bold mt-0.5">
+              {session.user.name?.split(' ')[0] ?? session.user.name}
+            </h1>
           </div>
           <div className="flex items-center gap-2 sm:gap-3">
             <Link
@@ -59,7 +61,7 @@ export default async function TechnicianLayout({
           </div>
         </div>
       </header>
-      <main className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-8">{children}</main>
+      <main className="mx-auto max-w-md px-4 py-6 md:max-w-xl">{children}</main>
     </div>
   );
 }

--- a/src/app/technician/layout.tsx
+++ b/src/app/technician/layout.tsx
@@ -5,7 +5,7 @@ import { auth, getSession } from '@/lib/auth';
 import { homeForRole } from '@/lib/roles';
 import { LogOut, Globe } from 'lucide-react';
 
-export default async function AttendantLayout({
+export default async function TechnicianLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -16,18 +16,18 @@ export default async function AttendantLayout({
   }
 
   const role = (session.user as { role?: string }).role;
-  if (role !== 'attendant') {
+  if (role !== 'technician') {
     redirect(homeForRole(role));
   }
 
-  const initial = session.user.name?.[0]?.toUpperCase() ?? 'A';
+  const initial = session.user.name?.[0]?.toUpperCase() ?? 'T';
 
   return (
     <div className="min-h-dvh bg-slate-50">
       <header className="bg-[#00477A] text-white">
         <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
           <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Attendant Dashboard</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-[#B6E9F4]">Technician Dashboard</p>
             <h1 className="text-xl font-bold mt-0.5">{session.user.name}</h1>
           </div>
           <div className="flex items-center gap-2 sm:gap-3">

--- a/src/app/technician/page.tsx
+++ b/src/app/technician/page.tsx
@@ -1,9 +1,10 @@
 import { MapPin, Phone, Wrench, CheckCircle2, Clock } from 'lucide-react';
 import { getMyJobs, getMyCompletedToday, updateMyJobStatus } from './actions';
 import { JOB_STATUS_COLORS } from '@/lib/work';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
 
 function todayLabel() {
-  return new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+  return new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'Africa/Kampala' });
 }
 
 export default async function TechnicianPage() {
@@ -90,22 +91,19 @@ export default async function TechnicianPage() {
                   )}
 
                   {/* Action button */}
-                  {(job.status === 'assigned' || job.status === 'in_progress') && (
-                    <form action={updateMyJobStatus}>
-                      <input type="hidden" name="jobId" value={job.id} />
-                      <input type="hidden" name="currentStatus" value={job.status ?? ''} />
-                      <button
-                        type="submit"
-                        className={`w-full h-12 rounded-xl text-white font-semibold text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
-                          isInProgress
-                            ? 'bg-teal-600 hover:bg-teal-700 focus:ring-teal-500'
-                            : 'bg-[#009FCE] hover:bg-[#007baa] focus:ring-[#009FCE]'
-                        }`}
-                      >
-                        {isInProgress ? 'Mark Complete' : 'Start Job'}
-                      </button>
-                    </form>
-                  )}
+                  <form action={updateMyJobStatus}>
+                    <input type="hidden" name="jobId" value={job.id} />
+                    <input type="hidden" name="currentStatus" value={job.status ?? ''} />
+                    <SubmitButton
+                      label={isInProgress ? 'Mark Complete' : 'Start Job'}
+                      pendingLabel="Working…"
+                      className={`w-full h-12 rounded-xl text-white font-semibold text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-60 ${
+                        isInProgress
+                          ? 'bg-teal-600 hover:bg-teal-700 focus:ring-teal-500'
+                          : 'bg-[#009FCE] hover:bg-[#007baa] focus:ring-[#009FCE]'
+                      }`}
+                    />
+                  </form>
                 </div>
               </li>
             );

--- a/src/app/technician/page.tsx
+++ b/src/app/technician/page.tsx
@@ -1,5 +1,5 @@
 import { Clock, CheckCircle2, MapPin } from 'lucide-react';
-import { getAttendantData } from './actions';
+import { getTechnicianData } from './actions';
 
 const statusColors: Record<string, string> = {
   pending: 'bg-amber-100 text-amber-800',
@@ -8,8 +8,8 @@ const statusColors: Record<string, string> = {
   cancelled: 'bg-gray-100 text-gray-600',
 };
 
-export default async function AttendantDashboardPage() {
-  const { jobs, stats } = await getAttendantData();
+export default async function TechnicianDashboardPage() {
+  const { jobs, stats } = await getTechnicianData();
 
   return (
     <div className="space-y-8">

--- a/src/app/technician/page.tsx
+++ b/src/app/technician/page.tsx
@@ -1,70 +1,160 @@
-import { Clock, CheckCircle2, MapPin } from 'lucide-react';
-import { getTechnicianData } from './actions';
+import { MapPin, Phone, Wrench, CheckCircle2, Clock } from 'lucide-react';
+import { getMyJobs, getMyCompletedToday, updateMyJobStatus } from './actions';
+import { JOB_STATUS_COLORS } from '@/lib/work';
 
-const statusColors: Record<string, string> = {
-  pending: 'bg-amber-100 text-amber-800',
-  in_progress: 'bg-blue-100 text-blue-800',
-  completed: 'bg-green-100 text-green-800',
-  cancelled: 'bg-gray-100 text-gray-600',
-};
+function todayLabel() {
+  return new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+}
 
-export default async function TechnicianDashboardPage() {
-  const { jobs, stats } = await getTechnicianData();
+export default async function TechnicianPage() {
+  const [activeJobs, completedToday] = await Promise.all([getMyJobs(), getMyCompletedToday()]);
+
+  // In-progress first, then assigned.
+  const sorted = [...activeJobs].sort((a, b) => {
+    if (a.status === 'in_progress' && b.status !== 'in_progress') return -1;
+    if (b.status === 'in_progress' && a.status !== 'in_progress') return 1;
+    return 0;
+  });
 
   return (
-    <div className="space-y-8">
-      <div className="grid grid-cols-2 gap-4">
-        <div className="bg-white rounded-xl border shadow-sm p-5 flex items-center gap-4">
-          <div className="h-11 w-11 rounded-lg bg-amber-50 text-amber-600 flex items-center justify-center">
-            <Clock size={20} />
-          </div>
-          <div>
-            <p className="text-2xl font-bold text-gray-900 tabular-nums">{stats.pending}</p>
-            <p className="text-sm text-gray-500">Pending Jobs</p>
-          </div>
+    <div className="space-y-6">
+      {/* Header block */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-bold text-gray-900">My Tasks</h2>
+          <p className="text-sm text-gray-500 mt-0.5">{todayLabel()}</p>
         </div>
-        <div className="bg-white rounded-xl border shadow-sm p-5 flex items-center gap-4">
-          <div className="h-11 w-11 rounded-lg bg-green-50 text-green-600 flex items-center justify-center">
-            <CheckCircle2 size={20} />
-          </div>
-          <div>
-            <p className="text-2xl font-bold text-gray-900 tabular-nums">{stats.completed}</p>
-            <p className="text-sm text-gray-500">Completed</p>
-          </div>
-        </div>
+        <span className="inline-flex items-center justify-center h-8 min-w-8 px-2 rounded-full bg-[#009FCE] text-white text-sm font-bold">
+          {activeJobs.length}
+        </span>
       </div>
 
-      <section className="bg-white rounded-xl border shadow-sm overflow-hidden">
-        <div className="px-5 py-4 border-b">
-          <h2 className="font-semibold text-gray-900">My Jobs</h2>
+      {/* Active jobs */}
+      {sorted.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white p-10 text-center">
+          <Wrench size={32} className="mx-auto text-gray-300 mb-3" />
+          <p className="font-medium text-gray-500">No tasks assigned right now</p>
+          <p className="text-sm text-gray-400 mt-1">Check back later or contact your manager.</p>
         </div>
-        {jobs.length === 0 ? (
-          <p className="px-5 py-12 text-center text-sm text-gray-400">No jobs assigned to you yet.</p>
-        ) : (
-          <ul className="divide-y">
-            {jobs.map((j) => {
-              const status = j.status ?? 'pending';
-              return (
-                <li key={j.id} className="px-5 py-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-gray-900">{j.customerName ?? 'Customer'}</p>
-                      <p className="text-xs text-gray-500 mt-0.5 truncate">{j.projectDescription ?? j.quotationNumber}</p>
-                      {j.location && (
-                        <p className="text-xs text-gray-400 mt-1 flex items-center gap-1">
-                          <MapPin size={12} /> {j.location}
-                        </p>
-                      )}
-                    </div>
-                    <span className={`shrink-0 inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${statusColors[status] ?? 'bg-gray-100 text-gray-600'}`}>
-                      {status.replace('_', ' ')}
+      ) : (
+        <ul className="space-y-3">
+          {sorted.map((job) => {
+            const isInProgress = job.status === 'in_progress';
+            const statusColor = JOB_STATUS_COLORS[job.status ?? 'assigned'] ?? 'bg-gray-100 text-gray-600';
+
+            return (
+              <li
+                key={job.id}
+                className={`rounded-2xl border bg-white shadow-sm overflow-hidden ${isInProgress ? 'ring-2 ring-[#009FCE]' : ''}`}
+              >
+                <div className="p-4 space-y-3">
+                  {/* Customer + status */}
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="font-bold text-gray-900 leading-tight">{job.customerName}</p>
+                    <span
+                      className={`shrink-0 inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${statusColor}`}
+                    >
+                      {(job.status ?? 'assigned').replace('_', ' ')}
                     </span>
                   </div>
-                </li>
-              );
-            })}
+
+                  {/* Description */}
+                  {job.projectDescription && (
+                    <p className="text-sm text-gray-600 line-clamp-2">{job.projectDescription}</p>
+                  )}
+
+                  {/* Location */}
+                  {job.location && (
+                    <p className="flex items-center gap-1.5 text-sm text-gray-500">
+                      <MapPin size={14} className="shrink-0 text-[#009FCE]" />
+                      {job.location}
+                    </p>
+                  )}
+
+                  {/* Address from client */}
+                  {(job.clientAddress || job.clientCity) && (
+                    <p className="text-xs text-gray-400 pl-0.5">
+                      {[job.clientAddress, job.clientCity].filter(Boolean).join(', ')}
+                    </p>
+                  )}
+
+                  {/* Phone */}
+                  {job.clientPhone && (
+                    <a
+                      href={`tel:${job.clientPhone}`}
+                      className="inline-flex items-center gap-2 rounded-lg bg-slate-50 border px-3 py-2 text-sm font-medium text-gray-700 hover:bg-slate-100 active:bg-slate-200 transition-colors"
+                    >
+                      <Phone size={14} className="text-[#009FCE]" />
+                      {job.clientPhone}
+                    </a>
+                  )}
+
+                  {/* Action button */}
+                  {(job.status === 'assigned' || job.status === 'in_progress') && (
+                    <form action={updateMyJobStatus}>
+                      <input type="hidden" name="jobId" value={job.id} />
+                      <input type="hidden" name="currentStatus" value={job.status ?? ''} />
+                      <button
+                        type="submit"
+                        className={`w-full h-12 rounded-xl text-white font-semibold text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+                          isInProgress
+                            ? 'bg-teal-600 hover:bg-teal-700 focus:ring-teal-500'
+                            : 'bg-[#009FCE] hover:bg-[#007baa] focus:ring-[#009FCE]'
+                        }`}
+                      >
+                        {isInProgress ? 'Mark Complete' : 'Start Job'}
+                      </button>
+                    </form>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* Completed today */}
+      {completedToday.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">
+            Completed today ({completedToday.length})
+          </h3>
+          <ul className="space-y-2">
+            {completedToday.map((job) => (
+              <li key={job.id} className="flex items-center gap-3 rounded-xl bg-white border px-4 py-3">
+                <CheckCircle2 size={16} className="shrink-0 text-teal-500" />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-800 truncate">{job.customerName}</p>
+                  {job.location && (
+                    <p className="text-xs text-gray-400 truncate">{job.location}</p>
+                  )}
+                </div>
+                <span className="ml-auto shrink-0 text-xs text-gray-400 capitalize">
+                  {(job.status ?? 'completed').replace('_', ' ')}
+                </span>
+              </li>
+            ))}
           </ul>
-        )}
+        </section>
+      )}
+
+      {/* Coming soon */}
+      <section>
+        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Coming soon</h3>
+        <div className="grid grid-cols-2 gap-3">
+          {[
+            { icon: MapPin, label: 'Map navigation' },
+            { icon: Clock, label: 'Time logs & field notes' },
+          ].map(({ icon: Icon, label }) => (
+            <div
+              key={label}
+              className="rounded-xl border border-dashed border-gray-200 bg-white/60 p-4 flex flex-col items-center gap-2 text-center"
+            >
+              <Icon size={20} className="text-gray-300" />
+              <p className="text-xs text-gray-400 font-medium">{label}</p>
+            </div>
+          ))}
+        </div>
       </section>
     </div>
   );

--- a/src/components/admin/RoleBarChart.tsx
+++ b/src/components/admin/RoleBarChart.tsx
@@ -36,8 +36,8 @@ export function RoleBarChart({ data }: { data: { role: string; count: number }[]
           cursor={{ fill: '#f3f4f6' }}
         />
         <Bar dataKey="count" name="Users" radius={[4, 4, 0, 0]}>
-          {chartData.map((_, i) => (
-            <Cell key={i} fill={i % 2 === 0 ? '#009FCE' : '#00477A'} />
+          {chartData.map((entry, i) => (
+            <Cell key={entry.name} fill={i % 2 === 0 ? '#009FCE' : '#00477A'} />
           ))}
         </Bar>
       </BarChart>

--- a/src/components/admin/RoleBarChart.tsx
+++ b/src/components/admin/RoleBarChart.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+
+const ROLE_LABELS: Record<string, string> = {
+  director: 'Director',
+  manager: 'Manager',
+  sales_manager: 'Sales Mgr',
+  accountant: 'Accountant',
+  receptionist: 'Reception',
+  technician: 'Technician',
+  customer: 'Customer',
+};
+
+export function RoleBarChart({ data }: { data: { role: string; count: number }[] }) {
+  const chartData = data.map((d) => ({
+    name: ROLE_LABELS[d.role] ?? d.role,
+    count: d.count,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <BarChart data={chartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+        <XAxis dataKey="name" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+        <YAxis allowDecimals={false} tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
+        <Tooltip
+          contentStyle={{ fontSize: 12, borderRadius: 8 }}
+          cursor={{ fill: '#f3f4f6' }}
+        />
+        <Bar dataKey="count" name="Users" radius={[4, 4, 0, 0]}>
+          {chartData.map((_, i) => (
+            <Cell key={i} fill={i % 2 === 0 ? '#009FCE' : '#00477A'} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/dashboard/AccountsNav.tsx
+++ b/src/components/dashboard/AccountsNav.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, CreditCard } from 'lucide-react';
+
+const ITEMS = [
+  { href: '/accounts', label: 'Overview', icon: LayoutDashboard, exact: true },
+  { href: '/accounts/payments', label: 'Payments', icon: CreditCard, exact: false },
+];
+
+export function AccountsNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex gap-1 overflow-x-auto" aria-label="Accounts sections">
+      {ITEMS.map(({ href, label, icon: Icon, exact }) => {
+        const active = exact ? pathname === href : pathname === href || pathname?.startsWith(href + '/');
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={`flex items-center gap-2 whitespace-nowrap px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              active
+                ? 'border-[#009FCE] text-[#00477A]'
+                : 'border-transparent text-slate-500 hover:text-[#00477A] hover:border-slate-300'
+            }`}
+          >
+            <Icon size={16} />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/dashboard/AccountsNav.tsx
+++ b/src/components/dashboard/AccountsNav.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, CreditCard } from 'lucide-react';
+import { LayoutDashboard, CreditCard, Users } from 'lucide-react';
 
 const ITEMS = [
   { href: '/accounts', label: 'Overview', icon: LayoutDashboard, exact: true },
   { href: '/accounts/payments', label: 'Payments', icon: CreditCard, exact: false },
+  { href: '/accounts/clients', label: 'Clients', icon: Users, exact: false },
 ];
 
 export function AccountsNav() {

--- a/src/components/dashboard/ComingSoon.tsx
+++ b/src/components/dashboard/ComingSoon.tsx
@@ -1,0 +1,21 @@
+export function ComingSoon({
+  module,
+  description,
+}: {
+  module: string;
+  description?: string;
+}) {
+  return (
+    <div className="bg-white rounded-xl border shadow-sm p-10 flex flex-col items-center text-center gap-4">
+      <div className="text-4xl">🚧</div>
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+        Coming soon
+      </span>
+      <div>
+        <p className="text-lg font-semibold text-gray-900">{module}</p>
+        {description && <p className="text-sm text-gray-500 mt-1">{description}</p>}
+      </div>
+      <p className="text-sm text-gray-400">This dashboard will be built in a later phase.</p>
+    </div>
+  );
+}

--- a/src/components/dashboard/DirectorNav.tsx
+++ b/src/components/dashboard/DirectorNav.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, CheckSquare, BarChart2 } from 'lucide-react';
+
+const ITEMS = [
+  { href: '/director', label: 'Overview', icon: LayoutDashboard, exact: true },
+  { href: '/director/approvals', label: 'Approvals', icon: CheckSquare, exact: false },
+  { href: '/director/reports', label: 'Reports', icon: BarChart2, exact: false },
+];
+
+export function DirectorNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex gap-1 overflow-x-auto" aria-label="Director sections">
+      {ITEMS.map(({ href, label, icon: Icon, exact }) => {
+        const active = exact ? pathname === href : pathname === href || pathname?.startsWith(href + '/');
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={`flex items-center gap-2 whitespace-nowrap px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              active
+                ? 'border-[#009FCE] text-[#00477A]'
+                : 'border-transparent text-slate-500 hover:text-[#00477A] hover:border-slate-300'
+            }`}
+          >
+            <Icon size={16} />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/dashboard/JobsBoard.tsx
+++ b/src/components/dashboard/JobsBoard.tsx
@@ -8,7 +8,7 @@ type JobRow = {
   assignee: { id: string | null; firstName: string | null; lastName: string | null } | null;
 };
 
-type Attendant = { id: string; firstName: string; lastName: string; email: string };
+type Technician = { id: string; firstName: string; lastName: string; email: string };
 
 export function JobsBoard({
   jobs,
@@ -17,7 +17,7 @@ export function JobsBoard({
   path,
 }: {
   jobs: JobRow[];
-  attendants: Attendant[];
+  attendants: Technician[];
   clientNameByUserId: Map<string, string>;
   path: string;
 }) {
@@ -62,7 +62,7 @@ export function JobsBoard({
               <form action={assignAttendant} className="space-y-1.5 pt-3">
                 <input type="hidden" name="jobId" value={job.id} />
                 <input type="hidden" name="_path" value={path} />
-                <label htmlFor={`att-${job.id}`} className="block text-xs font-medium text-gray-500">Attendant</label>
+                <label htmlFor={`att-${job.id}`} className="block text-xs font-medium text-gray-500">Technician</label>
                 <div className="flex gap-2">
                   <select
                     id={`att-${job.id}`}

--- a/src/components/dashboard/ReceptionNav.tsx
+++ b/src/components/dashboard/ReceptionNav.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, BookUser } from 'lucide-react';
+
+const ITEMS = [
+  { href: '/reception', label: 'Today', icon: LayoutDashboard, exact: true },
+  { href: '/reception/contacts', label: 'Contacts', icon: BookUser, exact: false },
+];
+
+export function ReceptionNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex gap-1 overflow-x-auto" aria-label="Reception sections">
+      {ITEMS.map(({ href, label, icon: Icon, exact }) => {
+        const active = exact ? pathname === href : pathname === href || pathname?.startsWith(href + '/');
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={`flex items-center gap-2 whitespace-nowrap px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              active
+                ? 'border-[#009FCE] text-[#00477A]'
+                : 'border-transparent text-slate-500 hover:text-[#00477A] hover:border-slate-300'
+            }`}
+          >
+            <Icon size={16} />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/dashboard/RevenueChart.tsx
+++ b/src/components/dashboard/RevenueChart.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+export function RevenueChart({ data }: { data: { month: string; total: number }[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <BarChart data={data} margin={{ top: 4, right: 8, left: 8, bottom: 0 }}>
+        <XAxis dataKey="month" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+        <YAxis
+          tickFormatter={(v) => `${(v / 1_000_000).toFixed(0)}M`}
+          tick={{ fontSize: 11 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          formatter={(value) => [`UGX ${Number(value ?? 0).toLocaleString('en-UG')}`, 'Revenue']}
+          contentStyle={{ fontSize: 12, borderRadius: 8 }}
+          cursor={{ fill: '#f1f5f9' }}
+        />
+        <Bar dataKey="total" name="Revenue" fill="#009FCE" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/dashboard/SalesNav.tsx
+++ b/src/components/dashboard/SalesNav.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, Users } from 'lucide-react';
+
+const ITEMS = [
+  { href: '/sales', label: 'Overview', icon: LayoutDashboard, exact: true },
+  { href: '/sales/leads', label: 'Leads', icon: Users, exact: false },
+];
+
+export function SalesNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex gap-1 overflow-x-auto" aria-label="Sales sections">
+      {ITEMS.map(({ href, label, icon: Icon, exact }) => {
+        const active = exact ? pathname === href : pathname === href || pathname?.startsWith(href + '/');
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={`flex items-center gap-2 whitespace-nowrap px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              active
+                ? 'border-[#009FCE] text-[#00477A]'
+                : 'border-transparent text-slate-500 hover:text-[#00477A] hover:border-slate-300'
+            }`}
+          >
+            <Icon size={16} />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/dashboard/SubmitButton.tsx
+++ b/src/components/dashboard/SubmitButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+
+export function SubmitButton({ label, pendingLabel = 'Working…', className }: {
+  label: string;
+  pendingLabel?: string;
+  className?: string;
+}) {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending} className={className}>
+      {pending ? pendingLabel : label}
+    </button>
+  );
+}

--- a/src/components/dashboard/TeamGrid.tsx
+++ b/src/components/dashboard/TeamGrid.tsx
@@ -22,7 +22,7 @@ export function TeamGrid({ team }: { team: TeamMember[] }) {
   if (team.length === 0) {
     return (
       <div className="bg-white rounded-xl border shadow-sm px-5 py-16 text-center text-sm text-gray-400">
-        No attendants found. Create attendant accounts in User Management.
+        No technicians found. Create technician accounts in User Management.
       </div>
     );
   }

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -6,7 +6,7 @@ import Footer from '../common/Footer';
 
 // Authenticated/app areas render their own chrome — never the marketing
 // header/footer (which otherwise overlaps dashboard content).
-const APP_PREFIXES = ['/admin', '/manager', '/attendant', '/portal', '/auth'];
+const APP_PREFIXES = ['/admin', '/manager', '/technician', '/director', '/sales', '/accounts', '/reception', '/portal', '/auth'];
 
 export default function ClientLayout({
   children,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -49,7 +49,7 @@ export const auth = betterAuth({
       ac,
       roles,
       defaultRole: "customer",
-      adminRoles: ["admin", "super_admin"],
+      adminRoles: ["super_admin"],
     }),
     // nextCookies must be the last plugin.
     nextCookies(),
@@ -65,7 +65,7 @@ export async function getSession() {
   return auth.api.getSession({ headers: await headers() });
 }
 
-const PRIVILEGED_ROLES = ["admin", "super_admin"];
+const PRIVILEGED_ROLES = ["super_admin"];
 
 // Returns the session only if the user holds an allowed role, else null.
 // Use in form actions (useActionState) that return { error } on rejection.

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -10,16 +10,22 @@ export const ac = createAccessControl(statement);
 // Roles for Afridrop. Admin-tier roles inherit the admin plugin's
 // user-management permissions; operational roles start with none.
 export const customer = ac.newRole({});
-export const attendant = ac.newRole({});
+export const technician = ac.newRole({});
+export const receptionist = ac.newRole({});
+export const accountant = ac.newRole({});
+export const salesManager = ac.newRole({});
 export const manager = ac.newRole({});
-export const admin = ac.newRole({ ...adminAc.statements });
+export const director = ac.newRole({});
 export const superAdmin = ac.newRole({ ...adminAc.statements });
 
 export const roles = {
   super_admin: superAdmin,
-  admin,
+  director,
   manager,
-  attendant,
+  sales_manager: salesManager,
+  accountant,
+  receptionist,
+  technician,
   customer,
 };
 

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -4,11 +4,18 @@ export function homeForRole(role?: string | null): string {
   switch (role) {
     case 'customer':
       return '/portal';
-    case 'attendant':
-      return '/attendant';
+    case 'technician':
+      return '/technician';
     case 'manager':
       return '/manager';
-    case 'admin':
+    case 'sales_manager':
+      return '/sales';
+    case 'accountant':
+      return '/accounts';
+    case 'receptionist':
+      return '/reception';
+    case 'director':
+      return '/director';
     case 'super_admin':
       return '/admin';
     default:

--- a/src/lib/work-actions.ts
+++ b/src/lib/work-actions.ts
@@ -9,7 +9,7 @@ import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
 import { scopedCustomerIds, JOB_STATUSES, type JobStatus } from '@/lib/work';
 
-const WORK_ROLES = ['manager', 'admin', 'super_admin'];
+const WORK_ROLES = ['manager', 'super_admin'];
 
 function revalidate(formData: FormData) {
   const path = (formData.get('_path') as string) || '/manager';

--- a/src/lib/work.ts
+++ b/src/lib/work.ts
@@ -19,7 +19,7 @@ export const JOB_STATUS_COLORS: Record<string, string> = {
   cancelled: 'bg-gray-100 text-gray-600',
 };
 
-type Role = 'super_admin' | 'admin' | 'manager' | 'attendant' | 'customer';
+type Role = 'super_admin' | 'director' | 'manager' | 'sales_manager' | 'accountant' | 'receptionist' | 'technician' | 'customer';
 
 function roleOf(session: Session): Role {
   return (session.user as { role?: Role }).role ?? 'customer';
@@ -29,7 +29,7 @@ function roleOf(session: Session): Role {
 // clients). Admin/super_admin return null = full access (no scope filter).
 export async function scopedCustomerIds(session: Session): Promise<string[] | null> {
   const role = roleOf(session);
-  if (role === 'admin' || role === 'super_admin') return null;
+  if (role === 'super_admin') return null;
 
   const rows = await db
     .select({ userId: clients.userId })
@@ -39,11 +39,11 @@ export async function scopedCustomerIds(session: Session): Promise<string[] | nu
   return rows.map((r) => r.userId).filter((id): id is string => Boolean(id));
 }
 
-export async function getActiveAttendants() {
+export async function getActiveTechnicians() {
   return db
     .select({ id: users.id, firstName: users.firstName, lastName: users.lastName, email: users.email })
     .from(users)
-    .where(and(eq(users.role, 'attendant'), isNull(users.deletedAt)));
+    .where(and(eq(users.role, 'technician'), isNull(users.deletedAt)));
 }
 
 // Jobs visible to the current scope, with the assignee joined in.

--- a/src/lib/work.ts
+++ b/src/lib/work.ts
@@ -26,7 +26,7 @@ function roleOf(session: Session): Role {
 }
 
 // The portal-account user IDs a manager is responsible for (their assigned
-// clients). Admin/super_admin return null = full access (no scope filter).
+// clients). super_admin returns null = full access (no scope filter).
 export async function scopedCustomerIds(session: Session): Promise<string[] | null> {
   const role = roleOf(session);
   if (role === 'super_admin') return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,7 +18,11 @@ export function proxy(request: NextRequest) {
     pathname.startsWith("/admin") ||
     pathname.startsWith("/portal") ||
     pathname.startsWith("/manager") ||
-    pathname.startsWith("/attendant");
+    pathname.startsWith("/technician") ||
+    pathname.startsWith("/director") ||
+    pathname.startsWith("/sales") ||
+    pathname.startsWith("/accounts") ||
+    pathname.startsWith("/reception");
 
   // Already logged in → leave the login page. Role-correct home is resolved by
   // the login page after sign-in; "/" is a safe neutral landing for any role.
@@ -40,7 +44,11 @@ export const config = {
     "/admin/:path*",
     "/portal/:path*",
     "/manager/:path*",
-    "/attendant/:path*",
+    "/technician/:path*",
+    "/director/:path*",
+    "/sales/:path*",
+    "/accounts/:path*",
+    "/reception/:path*",
     "/auth/:path*",
   ],
 };


### PR DESCRIPTION
## Summary

Replaces the old 5-role system (`super_admin / admin / manager / attendant / customer`) with the full Afridrop company hierarchy and gives every staff role its own access-scoped dashboard:

**Super Admin > Director > Manager > (Sales Manager / Accountant / Receptionist) > Technicians**, customers keep `/portal`.

Implements `plans/01-role-dashboards.md` (committed in this PR). Every phase was implemented by a dedicated agent, then spec-reviewed and quality-reviewed with fixes applied before the next phase started. Final whole-branch review verdict: **ready to merge, zero blocking issues**.

## Role system changes

- Final 8 roles: `super_admin, director, manager, sales_manager, accountant, receptionist, technician, customer`
- `attendant` renamed to `technician` (code + `scripts/migrate-roles.sql` data migration — **already run against the Neon DB: 0 rows matched**, no attendant accounts existed)
- Generic `admin` role removed; better-auth `adminRoles` now `["super_admin"]` only
- `homeForRole()` routes each role to its own dashboard after login; `proxy.ts` matcher covers all dashboard prefixes
- Defense-in-depth everywhere: middleware cookie check → server layout role guard → `requireRole()` on every data function and mutation

## Dashboards

| Route | Role | Contents |
|---|---|---|
| `/admin` | super_admin | System health cards, users-by-role chart, paginated audit log, regrouped sidebar (System + All Data), quick actions |
| `/director` | director | Revenue + monthly trend, active jobs, dept performance, quotation **Approve/Reject** with transactional `auditLogs` writes (first writers to that table) |
| `/manager` | manager | Pre-existing dashboard; attendant→technician terminology, super_admin access aligned |
| `/sales` | sales_manager | Pipeline stage cards (quotation approval statuses), conversion rate, lead Won/Lost management, read-only revenue |
| `/accounts` | accountant | **Read-only**: cash position (EAT month boundary), filterable paginated payments, receivables, client directory, 6-month trend |
| `/reception` | receptionist | Technician availability grid, recent inquiries, searchable contact directory with inline edit — **zero financial data** |
| `/technician` | technician | Mobile-first "My Tasks", Start/Mark-Complete buttons, own jobs only — **zero financial data** |

## Security highlights (caught + fixed during review loops)

- Director approvals: status pre-check in `WHERE` (prevents overwriting job-lifecycle statuses) + transaction-wrapped audit writes
- Technician/Sales/Reception mutations: UUID validation, transition/field allow-lists, ownership + soft-delete guards in `WHERE` with `.returning()` zero-row checks
- Sales lead mutation can't resurrect soft-deleted leads; reception edits limited to phone/email/address/city with per-column length caps
- Money-column isolation verified by grep: zero `totalAmount`/`estimatedBudget`/payment references in `src/app/technician/` and `src/app/reception/`
- Uganda timezone (`Africa/Kampala`) boundaries for "today"/"this month"; double-submit protection via shared `SubmitButton`

## Verification

- `npm run build` clean (42 routes), `npx tsc --noEmit` clean
- Isolation greps zero: no `'attendant'` / `role === 'admin'` comparisons anywhere in `src/`
- `requireRole` present on every data function across all 5 new data layers
- Role files agree: `permissions.ts`, `auth.ts`, `roles.ts`, admin `ASSIGNABLE_ROLES`

## Post-merge notes

- DB migration already applied (idempotent; `scripts/migrate-roles.sql` kept for reference/other envs)
- Super Admin creates Director / Sales Manager / Accountant / Receptionist accounts via `/admin/users` (new roles already assignable)
- Known accepted debt for follow-up plans: shared `DashboardLayout`/`DashboardNav` extraction (5 layout + 4 nav copies), approvals-engine reconciliation of director-approval vs manager-dispatch flows, appointments/invoices/leads-pipeline modules per plan's "Later Plans" section