### PR TITLE
feat: work management — customer quotation requests, duty assignment, director quotation lifecycle, technician reports & messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 # Uploaded images
 public/uploads/
 _legacy/
+
+# Playwright MCP browser artifacts
+.playwright-mcp/

--- a/drizzle/manual/0001_technician_reports.sql
+++ b/drizzle/manual/0001_technician_reports.sql
@@ -1,0 +1,18 @@
+-- Technician reports table
+-- Apply manually: psql $DATABASE_URL -f drizzle/manual/0001_technician_reports.sql
+
+CREATE TABLE IF NOT EXISTS technician_reports (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  technician_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  job_id          UUID REFERENCES quotations(id) ON DELETE SET NULL,
+  title           VARCHAR(150) NOT NULL,
+  content         TEXT NOT NULL,
+  undone_items    TEXT,
+  status          VARCHAR(20) NOT NULL DEFAULT 'draft',
+  submitted_at    TIMESTAMPTZ,
+  reviewed_by     UUID REFERENCES users(id) ON DELETE SET NULL,
+  reviewed_at     TIMESTAMPTZ,
+  review_note     TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/app/director/actions.ts
+++ b/src/app/director/actions.ts
@@ -192,3 +192,31 @@ export async function getPendingApprovals() {
     totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
   }));
 }
+
+// ── All Quotations (director full management) ──────────────────────────────
+export async function getAllQuotations() {
+  await requireRole(['director', 'super_admin']);
+
+  const rows = await db
+    .select({
+      id: quotations.id,
+      quotationNumber: quotations.quotationNumber,
+      customerName: quotations.customerName,
+      customerEmail: quotations.customerEmail,
+      projectDescription: quotations.projectDescription,
+      location: quotations.location,
+      totalAmount: quotations.totalAmount,
+      validUntil: quotations.validUntil,
+      notes: quotations.notes,
+      status: quotations.status,
+      createdAt: quotations.createdAt,
+    })
+    .from(quotations)
+    .where(isNull(quotations.deletedAt))
+    .orderBy(desc(quotations.createdAt));
+
+  return rows.map((r) => ({
+    ...r,
+    totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
+  }));
+}

--- a/src/app/director/approval-actions.ts
+++ b/src/app/director/approval-actions.ts
@@ -3,16 +3,31 @@
 import { db } from '@/db';
 import { quotations } from '@/db/schema/quotations';
 import { auditLogs } from '@/db/schema/payments';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, isNull } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Director-allowed status transitions: fromStatus → allowed toStatuses
+const DIRECTOR_TRANSITIONS: Record<string, string[]> = {
+  pending:     ['approved', 'rejected', 'on_hold', 'cancelled'],
+  reviewed:    ['approved', 'rejected', 'on_hold', 'cancelled'],
+  on_hold:     ['approved', 'rejected', 'pending', 'cancelled'],
+  approved:    ['on_hold', 'cancelled'],
+  rejected:    ['pending'],
+  assigned:    ['cancelled'],
+  in_progress: ['cancelled'],
+};
+// completed, verified, converted → no director transitions (terminal)
+
+const TERMINAL_STATUSES = ['completed', 'verified', 'converted'];
+
 async function transitionQuotation(
   quotationId: string,
-  newStatus: 'approved' | 'rejected',
+  newStatus: string,
   userId: string,
+  allowedFromStatuses: string[],
 ) {
   if (!quotationId || !UUID_RE.test(quotationId)) throw new Error('Invalid quotation id');
 
@@ -23,13 +38,13 @@ async function transitionQuotation(
       .where(
         and(
           eq(quotations.id, quotationId),
-          inArray(quotations.status as any, ['pending', 'reviewed']),
+          inArray(quotations.status as any, allowedFromStatuses),
         ),
       )
       .returning({ id: quotations.id });
 
     if (updated.length === 0) {
-      throw new Error('Quotation is no longer pending approval');
+      throw new Error('Quotation cannot be transitioned from its current status');
     }
 
     await tx.insert(auditLogs).values({
@@ -42,14 +57,50 @@ async function transitionQuotation(
   });
 }
 
+// Generalized director status transition — validates against the allow-list map.
+export async function setQuotationStatus(formData: FormData) {
+  const session = await requireRole(['director', 'super_admin']);
+  const quotationId = formData.get('quotationId') as string;
+  const targetStatus = formData.get('targetStatus') as string;
+
+  if (!quotationId) throw new Error('Missing quotationId');
+  if (!targetStatus) throw new Error('Missing targetStatus');
+
+  // Load current status to validate the transition
+  if (!UUID_RE.test(quotationId)) throw new Error('Invalid quotation id');
+  const row = await db.query.quotations.findFirst({
+    where: and(eq(quotations.id, quotationId), isNull(quotations.deletedAt)),
+    columns: { status: true },
+  });
+  if (!row) throw new Error('Quotation not found');
+
+  const currentStatus = row.status ?? 'pending';
+  if (TERMINAL_STATUSES.includes(currentStatus)) {
+    throw new Error('Quotation is in a terminal status and cannot be changed');
+  }
+
+  const allowed = DIRECTOR_TRANSITIONS[currentStatus] ?? [];
+  if (!allowed.includes(targetStatus)) {
+    throw new Error(`Cannot transition from '${currentStatus}' to '${targetStatus}'`);
+  }
+
+  await transitionQuotation(quotationId, targetStatus, session.user.id, [currentStatus]);
+
+  revalidatePath('/director/quotations');
+  revalidatePath('/director/approvals');
+  revalidatePath('/director');
+}
+
+// Thin wrappers — keep existing callers on /director/approvals working.
 export async function approveQuotation(formData: FormData) {
   const session = await requireRole(['director', 'super_admin']);
   const quotationId = formData.get('quotationId') as string;
   if (!quotationId) throw new Error('Missing quotationId');
 
-  await transitionQuotation(quotationId, 'approved', session.user.id);
+  await transitionQuotation(quotationId, 'approved', session.user.id, ['pending', 'reviewed', 'on_hold']);
 
   revalidatePath('/director/approvals');
+  revalidatePath('/director/quotations');
   revalidatePath('/director');
 }
 
@@ -58,8 +109,109 @@ export async function rejectQuotation(formData: FormData) {
   const quotationId = formData.get('quotationId') as string;
   if (!quotationId) throw new Error('Missing quotationId');
 
-  await transitionQuotation(quotationId, 'rejected', session.user.id);
+  await transitionQuotation(quotationId, 'rejected', session.user.id, ['pending', 'reviewed', 'on_hold']);
 
   revalidatePath('/director/approvals');
+  revalidatePath('/director/quotations');
   revalidatePath('/director');
+}
+
+// Director edits a quotation's mutable fields.
+export async function updateQuotation(formData: FormData) {
+  const session = await requireRole(['director', 'super_admin']);
+  const quotationId = formData.get('quotationId') as string;
+  if (!quotationId || !UUID_RE.test(quotationId)) throw new Error('Invalid quotation id');
+
+  const projectDescription = (formData.get('projectDescription') as string)?.trim();
+  const location = (formData.get('location') as string)?.trim() || null;
+  const totalAmountRaw = (formData.get('totalAmount') as string)?.trim();
+  const validUntilRaw = (formData.get('validUntil') as string)?.trim();
+  const notes = (formData.get('notes') as string)?.trim() || null;
+
+  const totalAmount = totalAmountRaw ? parseFloat(totalAmountRaw) : null;
+  if (totalAmountRaw && (isNaN(totalAmount!) || totalAmount! < 0)) {
+    throw new Error('Invalid total amount');
+  }
+
+  const validUntil = validUntilRaw || null;
+
+  await db.transaction(async (tx) => {
+    const row = await tx.query.quotations.findFirst({
+      where: and(eq(quotations.id, quotationId), isNull(quotations.deletedAt)),
+      columns: { status: true },
+    });
+    if (!row) throw new Error('Quotation not found');
+    if (TERMINAL_STATUSES.includes(row.status ?? '')) {
+      throw new Error('Cannot edit a quotation in a terminal status');
+    }
+
+    const setValues: Record<string, unknown> = { updatedAt: new Date() };
+    if (projectDescription) setValues.projectDescription = projectDescription;
+    if (location !== undefined) setValues.location = location;
+    if (totalAmountRaw !== undefined && totalAmountRaw !== '') setValues.totalAmount = String(totalAmount);
+    if (validUntil !== undefined) setValues.validUntil = validUntil;
+    if (notes !== undefined) setValues.notes = notes;
+
+    await tx.update(quotations).set(setValues).where(eq(quotations.id, quotationId));
+
+    await tx.insert(auditLogs).values({
+      userId: session.user.id,
+      action: 'quotation.updated',
+      resourceType: 'quotation',
+      resourceId: quotationId,
+      newValues: setValues,
+    });
+  });
+
+  revalidatePath('/director/quotations');
+}
+
+// Director creates a new quotation on behalf of a customer.
+export async function createQuotation(formData: FormData) {
+  const session = await requireRole(['director', 'super_admin']);
+
+  const customerName = (formData.get('customerName') as string)?.trim();
+  const customerEmail = (formData.get('customerEmail') as string)?.trim() || '';
+  const projectDescription = (formData.get('projectDescription') as string)?.trim();
+  const location = (formData.get('location') as string)?.trim() || null;
+  const totalAmountRaw = (formData.get('totalAmount') as string)?.trim();
+  const validUntilRaw = (formData.get('validUntil') as string)?.trim();
+  const notes = (formData.get('notes') as string)?.trim() || null;
+
+  if (!customerName) throw new Error('Customer name is required');
+  if (!projectDescription) throw new Error('Project description is required');
+
+  const totalAmount = totalAmountRaw ? parseFloat(totalAmountRaw) : null;
+  if (totalAmountRaw && (isNaN(totalAmount!) || totalAmount! < 0)) {
+    throw new Error('Invalid total amount');
+  }
+
+  const quotationNumber = `QT-${Date.now()}`;
+
+  await db.transaction(async (tx) => {
+    const [inserted] = await tx
+      .insert(quotations)
+      .values({
+        quotationNumber,
+        customerName,
+        customerEmail,
+        projectDescription,
+        location,
+        totalAmount: totalAmount !== null ? String(totalAmount) : null,
+        validUntil: validUntilRaw || null,
+        notes,
+        status: 'pending',
+      })
+      .returning({ id: quotations.id });
+
+    await tx.insert(auditLogs).values({
+      userId: session.user.id,
+      action: 'quotation.created',
+      resourceType: 'quotation',
+      resourceId: inserted.id,
+      newValues: { quotationNumber, customerName, status: 'pending' },
+    });
+  });
+
+  revalidatePath('/director/quotations');
 }

--- a/src/app/director/quotations/page.tsx
+++ b/src/app/director/quotations/page.tsx
@@ -1,0 +1,280 @@
+import { getAllQuotations } from '../actions';
+import {
+  setQuotationStatus,
+  updateQuotation,
+  createQuotation,
+} from '../approval-actions';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
+
+// Director-allowed transitions per current status
+const TRANSITIONS: Record<string, { label: string; status: string; style: string }[]> = {
+  pending: [
+    { label: 'Approve', status: 'approved', style: 'bg-green-600 text-white hover:bg-green-700' },
+    { label: 'Reject', status: 'rejected', style: 'border border-red-300 text-red-600 hover:bg-red-50' },
+    { label: 'Hold', status: 'on_hold', style: 'border border-amber-400 text-amber-700 hover:bg-amber-50' },
+    { label: 'Cancel', status: 'cancelled', style: 'border border-gray-300 text-gray-600 hover:bg-gray-50' },
+  ],
+  reviewed: [
+    { label: 'Approve', status: 'approved', style: 'bg-green-600 text-white hover:bg-green-700' },
+    { label: 'Reject', status: 'rejected', style: 'border border-red-300 text-red-600 hover:bg-red-50' },
+    { label: 'Hold', status: 'on_hold', style: 'border border-amber-400 text-amber-700 hover:bg-amber-50' },
+    { label: 'Cancel', status: 'cancelled', style: 'border border-gray-300 text-gray-600 hover:bg-gray-50' },
+  ],
+  on_hold: [
+    { label: 'Approve', status: 'approved', style: 'bg-green-600 text-white hover:bg-green-700' },
+    { label: 'Reject', status: 'rejected', style: 'border border-red-300 text-red-600 hover:bg-red-50' },
+    { label: 'Reopen', status: 'pending', style: 'border border-blue-300 text-blue-700 hover:bg-blue-50' },
+    { label: 'Cancel', status: 'cancelled', style: 'border border-gray-300 text-gray-600 hover:bg-gray-50' },
+  ],
+  approved: [
+    { label: 'Hold', status: 'on_hold', style: 'border border-amber-400 text-amber-700 hover:bg-amber-50' },
+    { label: 'Cancel', status: 'cancelled', style: 'border border-gray-300 text-gray-600 hover:bg-gray-50' },
+  ],
+  rejected: [
+    { label: 'Reopen', status: 'pending', style: 'border border-blue-300 text-blue-700 hover:bg-blue-50' },
+  ],
+  assigned: [
+    { label: 'Cancel', status: 'cancelled', style: 'border border-gray-300 text-gray-600 hover:bg-gray-50' },
+  ],
+  in_progress: [
+    { label: 'Cancel', status: 'cancelled', style: 'border border-gray-300 text-gray-600 hover:bg-gray-50' },
+  ],
+};
+
+function statusBadge(status: string | null) {
+  const s = status ?? 'pending';
+  const map: Record<string, string> = {
+    pending: 'bg-amber-100 text-amber-800',
+    reviewed: 'bg-purple-100 text-purple-800',
+    approved: 'bg-green-100 text-green-800',
+    rejected: 'bg-red-100 text-red-800',
+    on_hold: 'bg-amber-200 text-amber-900',
+    cancelled: 'bg-gray-100 text-gray-600',
+    assigned: 'bg-indigo-100 text-indigo-800',
+    in_progress: 'bg-blue-100 text-blue-800',
+    completed: 'bg-teal-100 text-teal-800',
+    verified: 'bg-green-200 text-green-900',
+    converted: 'bg-cyan-100 text-cyan-800',
+  };
+  const label: Record<string, string> = {
+    pending: 'Pending',
+    reviewed: 'Reviewed',
+    approved: 'Approved',
+    rejected: 'Rejected',
+    on_hold: 'On Hold',
+    cancelled: 'Cancelled',
+    assigned: 'Assigned',
+    in_progress: 'In Progress',
+    completed: 'Completed',
+    verified: 'Verified',
+    converted: 'Converted',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${map[s] ?? 'bg-gray-100 text-gray-600'}`}>
+      {label[s] ?? s}
+    </span>
+  );
+}
+
+function fmtUGX(amount: number | null) {
+  if (amount === null) return '—';
+  return `UGX ${amount.toLocaleString('en-UG')}`;
+}
+
+function fmtDate(date: Date | null | string) {
+  if (!date) return '—';
+  return new Date(date as string).toLocaleDateString('en-UG', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+export default async function DirectorQuotationsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; edit?: string; new?: string }>;
+}) {
+  const params = await searchParams;
+  const editId = params.edit ?? null;
+  const showNew = params.new === '1';
+  const errorMsg = params.error ?? null;
+
+  const allQuotations = await getAllQuotations();
+  const editQuotation = editId ? allQuotations.find((q) => q.id === editId) ?? null : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Quotation Management</h2>
+          <p className="text-sm text-gray-500 mt-1">Create, edit, and manage the full lifecycle of all quotations.</p>
+        </div>
+        <a
+          href="/director/quotations?new=1"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-[#00477A] text-white text-sm font-medium rounded-lg hover:bg-[#002B4A] transition"
+        >
+          + New Quotation
+        </a>
+      </div>
+
+      {errorMsg && (
+        <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">
+          {errorMsg}
+        </div>
+      )}
+
+      {/* New Quotation form */}
+      {showNew && (
+        <div className="bg-white rounded-xl border shadow-sm p-6 space-y-4">
+          <h3 className="text-base font-semibold text-gray-900">New Quotation</h3>
+          <form action={createQuotation} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Customer Name *</label>
+              <input name="customerName" required className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Customer Email</label>
+              <input name="customerEmail" type="email" className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="sm:col-span-2 space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Project Description *</label>
+              <textarea name="projectDescription" required rows={3} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Location</label>
+              <input name="location" className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Total Amount (UGX)</label>
+              <input name="totalAmount" type="number" min="0" step="0.01" className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Valid Until</label>
+              <input name="validUntil" type="date" className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="sm:col-span-2 space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Notes</label>
+              <textarea name="notes" rows={2} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="sm:col-span-2 flex gap-3">
+              <SubmitButton
+                label="Create Quotation"
+                pendingLabel="Creating…"
+                className="px-5 py-2 bg-[#00477A] text-white text-sm font-medium rounded-lg hover:bg-[#002B4A] transition disabled:opacity-60"
+              />
+              <a href="/director/quotations" className="px-5 py-2 border rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition">
+                Cancel
+              </a>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Edit panel */}
+      {editQuotation && (
+        <div className="bg-white rounded-xl border shadow-sm p-6 space-y-4">
+          <h3 className="text-base font-semibold text-gray-900">Edit Quotation — {editQuotation.quotationNumber}</h3>
+          <form action={updateQuotation} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <input type="hidden" name="quotationId" value={editQuotation.id} />
+            <div className="sm:col-span-2 space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Project Description</label>
+              <textarea name="projectDescription" rows={3} defaultValue={editQuotation.projectDescription} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Location</label>
+              <input name="location" defaultValue={editQuotation.location ?? ''} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Total Amount (UGX)</label>
+              <input name="totalAmount" type="number" min="0" step="0.01" defaultValue={editQuotation.totalAmount ?? ''} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Valid Until</label>
+              <input name="validUntil" type="date" defaultValue={editQuotation.validUntil ?? ''} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="sm:col-span-2 space-y-1">
+              <label className="block text-xs font-medium text-gray-600">Notes</label>
+              <textarea name="notes" rows={2} defaultValue={editQuotation.notes ?? ''} className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]" />
+            </div>
+            <div className="sm:col-span-2 flex gap-3">
+              <SubmitButton
+                label="Save Changes"
+                pendingLabel="Saving…"
+                className="px-5 py-2 bg-[#00477A] text-white text-sm font-medium rounded-lg hover:bg-[#002B4A] transition disabled:opacity-60"
+              />
+              <a href="/director/quotations" className="px-5 py-2 border rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition">
+                Cancel
+              </a>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Quotations table */}
+      <div className="bg-white rounded-xl border shadow-sm overflow-hidden">
+        {allQuotations.length === 0 ? (
+          <p className="text-sm text-slate-400 px-6 py-12 text-center">No quotations yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Number</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Customer</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide hidden md:table-cell">Description</th>
+                  <th className="text-right px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide hidden sm:table-cell">Amount</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Status</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide hidden lg:table-cell">Created</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wide">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {allQuotations.map((q) => {
+                  const transitions = TRANSITIONS[q.status ?? 'pending'] ?? [];
+                  return (
+                    <tr key={q.id} className="hover:bg-slate-50 transition-colors align-top">
+                      <td className="px-4 py-3 font-mono text-xs text-slate-600 whitespace-nowrap">{q.quotationNumber}</td>
+                      <td className="px-4 py-3 text-slate-900 whitespace-nowrap">
+                        <p className="font-medium">{q.customerName}</p>
+                        <p className="text-xs text-slate-400">{q.customerEmail}</p>
+                      </td>
+                      <td className="px-4 py-3 text-slate-600 hidden md:table-cell max-w-xs">
+                        <p className="line-clamp-2 text-xs">{q.projectDescription}</p>
+                        {q.location && <p className="text-xs text-slate-400 mt-0.5">📍 {q.location}</p>}
+                      </td>
+                      <td className="px-4 py-3 text-right text-slate-700 whitespace-nowrap hidden sm:table-cell">
+                        {fmtUGX(q.totalAmount)}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">{statusBadge(q.status)}</td>
+                      <td className="px-4 py-3 text-xs text-slate-400 whitespace-nowrap hidden lg:table-cell">{fmtDate(q.createdAt)}</td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-1.5 items-center">
+                          {/* Edit link */}
+                          <a
+                            href={`/director/quotations?edit=${q.id}`}
+                            className="px-2.5 py-1 text-xs font-medium rounded-md border border-[#00477A] text-[#00477A] hover:bg-slate-50 transition"
+                          >
+                            Edit
+                          </a>
+                          {/* Status transitions */}
+                          {transitions.map((t) => (
+                            <form key={t.status} action={setQuotationStatus}>
+                              <input type="hidden" name="quotationId" value={q.id} />
+                              <input type="hidden" name="targetStatus" value={t.status} />
+                              <SubmitButton
+                                label={t.label}
+                                pendingLabel="…"
+                                className={`px-2.5 py-1 text-xs font-medium rounded-md transition ${t.style} disabled:opacity-60`}
+                              />
+                            </form>
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/manager/actions.ts
+++ b/src/app/manager/actions.ts
@@ -81,21 +81,42 @@ export async function getManagerTeam() {
 export async function getManagerMessagesView() {
   const session = await requireRole(['manager', 'super_admin', 'director']);
   const scope = await scopedCustomerIds(session);
-  const threadsMap = await getThreads(scope);
+  const technicians = await getActiveTechnicians();
+  const technicianIds = technicians.map((t) => t.id);
+
+  // Scoped managers see their client threads AND all technician threads.
+  const effectiveScope =
+    scope === null ? null : [...new Set([...scope, ...technicianIds])];
+
+  const threadsMap = await getThreads(effectiveScope);
   const clientNameByUserId = await clientNameMap(session.user.id);
+
+  const techNameById = new Map(
+    technicians.map((t) => [t.id, [t.firstName, t.lastName].filter(Boolean).join(' ') || t.email]),
+  );
 
   const threads = Array.from(threadsMap.entries()).map(([userId, t]) => ({
     userId,
-    name: clientNameByUserId.get(userId) ?? t.latest.subject,
+    name:
+      clientNameByUserId.get(userId) ??
+      techNameById.get(userId) ??
+      t.latest.subject,
     latest: t.latest,
     unread: t.unread,
     count: t.count,
   }));
 
-  // Clients with a portal account can receive messages.
-  const recipients = (await getManagerClients())
+  // Clients with a portal account can receive messages, plus all technicians.
+  const clientRecipients = (await getManagerClients())
     .filter((c) => c.userId)
     .map((c) => ({ userId: c.userId as string, name: c.name }));
+
+  const techRecipients = technicians.map((t) => ({
+    userId: t.id,
+    name: ([t.firstName, t.lastName].filter(Boolean).join(' ') || t.email) + ' (Technician)',
+  }));
+
+  const recipients = [...clientRecipients, ...techRecipients];
 
   return { threads, recipients };
 }

--- a/src/app/manager/report-actions.ts
+++ b/src/app/manager/report-actions.ts
@@ -1,0 +1,76 @@
+'use server';
+
+import { db } from '@/db';
+import { technicianReports } from '@/db/schema/reports';
+import { users } from '@/db/schema/auth';
+import { quotations } from '@/db/schema/quotations';
+import { alias } from 'drizzle-orm/pg-core';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const techUsers = alias(users, 'tech_users');
+const revUsers = alias(users, 'rev_users');
+
+export async function getTeamReports() {
+  await requireRole(['manager', 'director', 'super_admin']);
+
+  return db
+    .select({
+      id: technicianReports.id,
+      title: technicianReports.title,
+      content: technicianReports.content,
+      undoneItems: technicianReports.undoneItems,
+      status: technicianReports.status,
+      submittedAt: technicianReports.submittedAt,
+      reviewedAt: technicianReports.reviewedAt,
+      reviewNote: technicianReports.reviewNote,
+      jobId: technicianReports.jobId,
+      techFirstName: techUsers.firstName,
+      techLastName: techUsers.lastName,
+      jobQuotationNumber: quotations.quotationNumber,
+      jobCustomerName: quotations.customerName,
+      reviewerFirstName: revUsers.firstName,
+      reviewerLastName: revUsers.lastName,
+    })
+    .from(technicianReports)
+    .leftJoin(techUsers, eq(technicianReports.technicianId, techUsers.id))
+    .leftJoin(quotations, eq(technicianReports.jobId, quotations.id))
+    .leftJoin(revUsers, eq(technicianReports.reviewedBy, revUsers.id))
+    .where(inArray(technicianReports.status as any, ['submitted', 'reviewed']))
+    .orderBy(desc(technicianReports.submittedAt));
+}
+
+export async function markReportReviewed(formData: FormData) {
+  const session = await requireRole(['manager', 'director', 'super_admin']);
+
+  const reportId = (formData.get('reportId') as string)?.trim();
+  if (!reportId || !UUID_RE.test(reportId)) throw new Error('Invalid report id');
+
+  const reviewNote = ((formData.get('reviewNote') as string) ?? '').trim().slice(0, 1000) || null;
+
+  const updated = await db
+    .update(technicianReports)
+    .set({
+      status: 'reviewed',
+      reviewedBy: session.user.id,
+      reviewedAt: new Date(),
+      reviewNote,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(technicianReports.id, reportId),
+        eq(technicianReports.status, 'submitted'),
+      ),
+    )
+    .returning({ id: technicianReports.id });
+
+  if (updated.length === 0) {
+    throw new Error('Report is not awaiting review');
+  }
+
+  revalidatePath('/manager/reports');
+}

--- a/src/app/manager/reports/page.tsx
+++ b/src/app/manager/reports/page.tsx
@@ -1,0 +1,113 @@
+import { getTeamReports, markReportReviewed } from '../report-actions';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
+
+export default async function ManagerReportsPage() {
+  const reports = await getTeamReports();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-bold text-gray-900">Team Reports</h2>
+        <p className="text-sm text-gray-500 mt-1">Review work reports submitted by your technicians.</p>
+      </div>
+
+      {reports.length === 0 ? (
+        <div className="bg-white rounded-xl border shadow-sm px-6 py-16 text-center">
+          <p className="text-sm text-gray-400">No submitted or reviewed reports yet.</p>
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {reports.map((r) => {
+            const techName = [r.techFirstName, r.techLastName].filter(Boolean).join(' ') || 'Unknown technician';
+            const reviewerName = [r.reviewerFirstName, r.reviewerLastName].filter(Boolean).join(' ');
+
+            return (
+              <li key={r.id} className="bg-white rounded-xl border shadow-sm p-5 space-y-3">
+                {/* Header row */}
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="font-semibold text-gray-900 truncate">{r.title}</h3>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      {techName}
+                      {r.jobQuotationNumber && (
+                        <> &middot; Job <span className="font-medium">{r.jobQuotationNumber}</span>
+                          {r.jobCustomerName && <> ({r.jobCustomerName})</>}
+                        </>
+                      )}
+                      {r.submittedAt && (
+                        <> &middot; Submitted {new Date(r.submittedAt).toLocaleDateString()}</>
+                      )}
+                    </p>
+                  </div>
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium shrink-0 ${
+                      r.status === 'submitted'
+                        ? 'bg-blue-100 text-blue-800'
+                        : 'bg-green-100 text-green-800'
+                    }`}
+                  >
+                    {r.status === 'submitted' ? 'Submitted' : 'Reviewed'}
+                  </span>
+                </div>
+
+                {/* Content */}
+                <p className="text-sm text-gray-700 whitespace-pre-wrap">{r.content}</p>
+
+                {/* Outstanding items */}
+                {r.undoneItems && (
+                  <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3">
+                    <p className="text-xs font-semibold text-amber-800 mb-1">Outstanding items</p>
+                    <p className="text-sm text-amber-700 whitespace-pre-wrap">{r.undoneItems}</p>
+                  </div>
+                )}
+
+                {/* Review note (already reviewed) */}
+                {r.status === 'reviewed' && (
+                  <div className="rounded-lg bg-green-50 border border-green-200 px-4 py-3">
+                    <p className="text-xs font-semibold text-green-800 mb-1">
+                      Review note
+                      {reviewerName && <span className="font-normal"> &mdash; {reviewerName}</span>}
+                      {r.reviewedAt && (
+                        <span className="font-normal"> on {new Date(r.reviewedAt).toLocaleDateString()}</span>
+                      )}
+                    </p>
+                    {r.reviewNote ? (
+                      <p className="text-sm text-green-700 whitespace-pre-wrap">{r.reviewNote}</p>
+                    ) : (
+                      <p className="text-sm text-green-600 italic">No note provided.</p>
+                    )}
+                  </div>
+                )}
+
+                {/* Review form (submitted only) */}
+                {r.status === 'submitted' && (
+                  <form action={markReportReviewed} className="space-y-2 pt-1">
+                    <input type="hidden" name="reportId" value={r.id} />
+                    <div>
+                      <label htmlFor={`note-${r.id}`} className="block text-xs font-medium text-gray-500 mb-1">
+                        Review note <span className="font-normal text-gray-400">(optional)</span>
+                      </label>
+                      <textarea
+                        id={`note-${r.id}`}
+                        name="reviewNote"
+                        rows={2}
+                        maxLength={1000}
+                        placeholder="Add a review note…"
+                        className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]"
+                      />
+                    </div>
+                    <SubmitButton
+                      label="Mark Reviewed"
+                      pendingLabel="Saving…"
+                      className="inline-flex items-center gap-2 px-4 py-2 bg-[#00477A] text-white text-sm font-medium rounded-lg hover:bg-[#002B4A] transition disabled:opacity-60"
+                    />
+                  </form>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/portal/actions.ts
+++ b/src/app/portal/actions.ts
@@ -103,6 +103,7 @@ export async function submitServiceRequest(formData: FormData) {
   const serviceType = formData.get('serviceType') as string;
   const description = formData.get('description') as string;
   const preferredDate = formData.get('date') as string;
+  const location = (formData.get('location') as string | null)?.trim() || null;
 
   const serviceTypeLabels: Record<string, string> = {
     maintenance: 'Regular Maintenance',
@@ -111,13 +112,23 @@ export async function submitServiceRequest(formData: FormData) {
     repair: 'Repair Service',
   };
 
+  let serviceLabel: string;
+  if (serviceType === 'other') {
+    const custom = (formData.get('customServiceType') as string | null)?.trim().slice(0, 100) ?? '';
+    if (!custom) throw new Error('Please describe the service you need.');
+    serviceLabel = custom;
+  } else {
+    serviceLabel = serviceTypeLabels[serviceType] || serviceType;
+  }
+
   await db.insert(quotations).values({
     quotationNumber: `SVC-${Date.now()}`,
     customerId: user.id,
     customerName: `${user.firstName} ${user.lastName}`,
     customerEmail: user.email,
     projectDescription: description,
-    notes: serviceTypeLabels[serviceType] || serviceType,
+    notes: serviceLabel,
+    location,
     validUntil: preferredDate || null,
     status: 'pending',
   });

--- a/src/app/portal/dashboard/components/ScheduleTab.tsx
+++ b/src/app/portal/dashboard/components/ScheduleTab.tsx
@@ -30,6 +30,7 @@ const serviceTypeOptions = [
   { value: 'cleaning', label: 'Deep Cleaning' },
   { value: 'inspection', label: 'Safety Inspection' },
   { value: 'repair', label: 'Repair Service' },
+  { value: 'other', label: 'Other (describe below)' },
 ];
 
 export default function ScheduleTab({ data }: { data: ServiceRequest[] }) {
@@ -42,6 +43,7 @@ export default function ScheduleTab({ data }: { data: ServiceRequest[] }) {
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [selectedServiceType, setSelectedServiceType] = useState('maintenance');
 
   // Filter data
   const filteredData = data.filter(item => {
@@ -159,7 +161,12 @@ export default function ScheduleTab({ data }: { data: ServiceRequest[] }) {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-1">Service Type</label>
-                <select name="serviceType" className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#009FCE]/50">
+                <select
+                  name="serviceType"
+                  value={selectedServiceType}
+                  onChange={(e) => setSelectedServiceType(e.target.value)}
+                  className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#009FCE]/50"
+                >
                   {serviceTypeOptions.map(opt => (
                     <option key={opt.value} value={opt.value}>{opt.label}</option>
                   ))}
@@ -169,6 +176,28 @@ export default function ScheduleTab({ data }: { data: ServiceRequest[] }) {
                 <label className="block text-sm font-medium text-slate-700 mb-1">Preferred Date</label>
                 <input type="date" name="date" className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#009FCE]/50" required />
               </div>
+            </div>
+            {selectedServiceType === 'other' && (
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Describe the service you need <span className="text-red-500">*</span></label>
+                <input
+                  type="text"
+                  name="customServiceType"
+                  maxLength={100}
+                  className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#009FCE]/50"
+                  placeholder="e.g. Pest control, generator servicing…"
+                  required
+                />
+              </div>
+            )}
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Location / Address <span className="text-slate-400 font-normal">(optional)</span></label>
+              <input
+                type="text"
+                name="location"
+                className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#009FCE]/50"
+                placeholder="e.g. Plot 12, Kampala Road, Kampala"
+              />
             </div>
             <div>
               <label className="block text-sm font-medium text-slate-700 mb-1">Description</label>

--- a/src/app/sales/actions.ts
+++ b/src/app/sales/actions.ts
@@ -6,8 +6,9 @@ import { quotations } from '@/db/schema/quotations';
 import { payments } from '@/db/schema/payments';
 import { count, eq, inArray, isNull, sum, and, desc, gte, sql } from 'drizzle-orm';
 import { requireRole } from '@/lib/auth';
+import { scopedCustomerIds, getJobs, getActiveTechnicians } from '@/lib/work';
 
-const APPROVAL_STATUSES = ['pending', 'reviewed', 'approved', 'rejected', 'converted'] as const;
+const APPROVAL_STATUSES = ['pending', 'reviewed', 'approved', 'rejected', 'converted', 'on_hold', 'cancelled'] as const;
 
 // ── Sales Overview ──────────────────────────────────────────────────────────
 export async function getSalesOverview() {
@@ -65,12 +66,14 @@ export async function getSalesOverview() {
   const approved = byStatus['approved'] ?? 0;
   const rejected = byStatus['rejected'] ?? 0;
   const converted = byStatus['converted'] ?? 0;
-  const total = pending + reviewed + approved + rejected + converted;
+  const on_hold = byStatus['on_hold'] ?? 0;
+  const cancelled = byStatus['cancelled'] ?? 0;
+  const total = pending + reviewed + approved + rejected + converted + on_hold;
   // Denominator: approval-workflow statuses only — intentionally excludes job-lifecycle rows (director reports use all quotations)
   const conversionRate = total > 0 ? Math.round(((approved + converted) / total) * 100) : 0;
 
   return {
-    pipeline: { pending, reviewed, approved, rejected, converted },
+    pipeline: { pending, reviewed, approved, rejected, converted, on_hold, cancelled },
     conversionRate,
     totalPipelineQuotations: total,
     leadsCount: Number(leadsRow?.value ?? 0),
@@ -123,4 +126,19 @@ export async function getRecentQuotations() {
     ...r,
     totalAmount: r.totalAmount ? Number(r.totalAmount) : null,
   }));
+}
+
+// ── Jobs (full scope — sales_manager sees all) ───────────────────────────────
+export async function getSalesJobsView() {
+  const session = await requireRole(['sales_manager', 'super_admin', 'director']);
+  const scope = await scopedCustomerIds(session);
+  const [jobs, attendants] = await Promise.all([getJobs(scope), getActiveTechnicians()]);
+  // Build a client name map from job rows themselves (customerName stored on quotation)
+  const clientNameByUserId = new Map<string, string>();
+  for (const { job } of jobs) {
+    if (job.customerId && job.customerName) {
+      clientNameByUserId.set(job.customerId, job.customerName);
+    }
+  }
+  return { jobs, attendants, clientNameByUserId };
 }

--- a/src/app/sales/jobs/page.tsx
+++ b/src/app/sales/jobs/page.tsx
@@ -1,0 +1,16 @@
+import { getSalesJobsView } from '../actions';
+import { JobsBoard } from '@/components/dashboard/JobsBoard';
+
+export default async function SalesJobsPage() {
+  const { jobs, attendants, clientNameByUserId } = await getSalesJobsView();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-bold text-gray-900">Jobs &amp; Service Requests</h2>
+        <p className="text-sm text-gray-500 mt-1">Assign technicians, track progress, and verify completed work.</p>
+      </div>
+      <JobsBoard jobs={jobs} attendants={attendants} clientNameByUserId={clientNameByUserId} path="/sales/jobs" />
+    </div>
+  );
+}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { getSalesOverview, getRecentQuotations } from './actions';
 import { RevenueChart } from '@/components/dashboard/RevenueChart';
 import { ComingSoon } from '@/components/dashboard/ComingSoon';
-import { TrendingUp, Users, CheckCircle, XCircle, Clock, Eye, RefreshCw } from 'lucide-react';
+import { TrendingUp, Users, CheckCircle, XCircle, Clock, Eye, RefreshCw, PauseCircle, Ban } from 'lucide-react';
 
 function StatCard({
   label,
@@ -45,11 +45,12 @@ function statusLabel(status: string | null): string {
     case 'approved': return 'Approved';
     case 'rejected': return 'Rejected';
     case 'converted': return 'Converted';
+    case 'on_hold': return 'On Hold';
+    case 'cancelled': return 'Cancelled';
     case 'assigned': return 'Assigned';
     case 'in_progress': return 'In Progress';
     case 'completed': return 'Completed';
     case 'verified': return 'Verified';
-    case 'cancelled': return 'Cancelled';
     default: return status ?? '—';
   }
 }
@@ -61,6 +62,8 @@ function statusBadgeClass(status: string | null): string {
     case 'approved': return 'bg-green-100 text-green-800';
     case 'rejected': return 'bg-red-100 text-red-800';
     case 'converted': return 'bg-[#009FCE]/15 text-[#00477A]';
+    case 'on_hold': return 'bg-amber-200 text-amber-900';
+    case 'cancelled': return 'bg-gray-100 text-gray-600';
     default: return 'bg-slate-100 text-slate-700';
   }
 }
@@ -84,12 +87,14 @@ export default async function SalesPage() {
       {/* Pipeline stage cards */}
       <section>
         <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">Pipeline Stages</h3>
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-3">
           <StatCard label="Pending" value={pipeline.pending} icon={Clock} accent="bg-amber-500" />
           <StatCard label="Reviewed" value={pipeline.reviewed} icon={Eye} accent="bg-blue-500" />
           <StatCard label="Approved" value={pipeline.approved} icon={CheckCircle} accent="bg-green-600" />
           <StatCard label="Converted" value={pipeline.converted} icon={RefreshCw} accent="bg-[#009FCE]" />
           <StatCard label="Rejected" value={pipeline.rejected} icon={XCircle} accent="bg-red-500" />
+          <StatCard label="On Hold" value={pipeline.on_hold} icon={PauseCircle} accent="bg-amber-600" />
+          <StatCard label="Cancelled" value={pipeline.cancelled} icon={Ban} accent="bg-gray-500" />
         </div>
       </section>
 

--- a/src/app/technician/message-actions.ts
+++ b/src/app/technician/message-actions.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { db } from '@/db';
+import { messages } from '@/db/schema/messages';
+import { and, asc, eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth';
+
+export async function getMyThread() {
+  const session = await requireRole(['technician']);
+
+  // Mark office replies (outbound) as read before returning.
+  await db
+    .update(messages)
+    .set({ isRead: true, updatedAt: new Date() })
+    .where(
+      and(
+        eq(messages.userId, session.user.id),
+        eq(messages.direction, 'outbound'),
+        eq(messages.isRead, false),
+      ),
+    );
+
+  return db
+    .select()
+    .from(messages)
+    .where(eq(messages.userId, session.user.id))
+    .orderBy(asc(messages.createdAt));
+}
+
+export async function sendTechnicianMessage(formData: FormData) {
+  const session = await requireRole(['technician']);
+
+  const content = (formData.get('content') as string)?.trim();
+  if (!content) throw new Error('Message content is required');
+  if (content.length > 2000) throw new Error('Message too long (max 2000 characters)');
+
+  const subject = 'Task clarification';
+
+  await db.insert(messages).values({
+    userId: session.user.id,
+    subject,
+    content,
+    direction: 'inbound',
+    isRead: false,
+    status: 'sent',
+  });
+
+  revalidatePath('/technician/messages');
+}

--- a/src/app/technician/messages/page.tsx
+++ b/src/app/technician/messages/page.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+import { ArrowLeft, MessageSquare } from 'lucide-react';
+import { getMyThread, sendTechnicianMessage } from '../message-actions';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
+
+export default async function TechnicianMessagesPage() {
+  const thread = await getMyThread();
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/technician"
+        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-[#00477A] transition-colors"
+      >
+        <ArrowLeft size={16} /> Back to tasks
+      </Link>
+
+      <div>
+        <h2 className="text-lg font-bold text-gray-900">Ask about a task</h2>
+        <p className="text-sm text-gray-500 mt-0.5">Send a message to your manager or the office.</p>
+      </div>
+
+      {/* Chat thread */}
+      {thread.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white p-10 text-center">
+          <MessageSquare size={32} className="mx-auto text-gray-300 mb-3" />
+          <p className="font-medium text-gray-500">No messages yet</p>
+          <p className="text-sm text-gray-400 mt-1">Send your first message below.</p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {thread.map((m) => {
+            const isMine = m.direction === 'inbound';
+            return (
+              <li key={m.id} className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={`max-w-xs sm:max-w-sm rounded-2xl px-4 py-3 shadow-sm ${
+                    isMine
+                      ? 'bg-[#009FCE] text-white rounded-br-sm'
+                      : 'bg-white border text-gray-800 rounded-bl-sm'
+                  }`}
+                >
+                  <p className="text-sm leading-relaxed">{m.content}</p>
+                  <p className={`text-xs mt-1.5 ${isMine ? 'text-[#B6E9F4]' : 'text-gray-400'}`}>
+                    {m.createdAt ? new Date(m.createdAt).toLocaleString('en-UG', { dateStyle: 'short', timeStyle: 'short' }) : ''}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* Compose */}
+      <section className="bg-white rounded-2xl border shadow-sm p-4">
+        <form action={sendTechnicianMessage} className="space-y-3">
+          <textarea
+            name="content"
+            required
+            maxLength={2000}
+            rows={4}
+            placeholder="Type your message…"
+            className="w-full px-3 py-2.5 border rounded-xl text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]"
+          />
+          <SubmitButton
+            label="Send Message"
+            pendingLabel="Sending…"
+            className="w-full h-12 rounded-xl bg-[#009FCE] text-white font-semibold text-sm hover:bg-[#007baa] transition-colors focus:outline-none focus:ring-2 focus:ring-[#009FCE] focus:ring-offset-2 disabled:opacity-60"
+          />
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/app/technician/page.tsx
+++ b/src/app/technician/page.tsx
@@ -1,4 +1,5 @@
-import { MapPin, Phone, Wrench, CheckCircle2, Clock } from 'lucide-react';
+import Link from 'next/link';
+import { MapPin, Phone, Wrench, CheckCircle2, FileText, MessageSquare } from 'lucide-react';
 import { getMyJobs, getMyCompletedToday, updateMyJobStatus } from './actions';
 import { JOB_STATUS_COLORS } from '@/lib/work';
 import { SubmitButton } from '@/components/dashboard/SubmitButton';
@@ -136,22 +137,35 @@ export default async function TechnicianPage() {
         </section>
       )}
 
+      {/* Quick links */}
+      <section>
+        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">More</h3>
+        <div className="grid grid-cols-2 gap-3">
+          <Link
+            href="/technician/reports"
+            className="rounded-xl border bg-white p-4 flex flex-col items-center gap-2 text-center hover:border-[#009FCE] hover:shadow-sm transition-all active:bg-slate-50"
+          >
+            <FileText size={20} className="text-[#009FCE]" />
+            <p className="text-xs text-gray-700 font-medium">My Reports</p>
+          </Link>
+          <Link
+            href="/technician/messages"
+            className="rounded-xl border bg-white p-4 flex flex-col items-center gap-2 text-center hover:border-[#009FCE] hover:shadow-sm transition-all active:bg-slate-50"
+          >
+            <MessageSquare size={20} className="text-[#009FCE]" />
+            <p className="text-xs text-gray-700 font-medium">Ask about a task</p>
+          </Link>
+        </div>
+      </section>
+
       {/* Coming soon */}
       <section>
         <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Coming soon</h3>
         <div className="grid grid-cols-2 gap-3">
-          {[
-            { icon: MapPin, label: 'Map navigation' },
-            { icon: Clock, label: 'Time logs & field notes' },
-          ].map(({ icon: Icon, label }) => (
-            <div
-              key={label}
-              className="rounded-xl border border-dashed border-gray-200 bg-white/60 p-4 flex flex-col items-center gap-2 text-center"
-            >
-              <Icon size={20} className="text-gray-300" />
-              <p className="text-xs text-gray-400 font-medium">{label}</p>
-            </div>
-          ))}
+          <div className="rounded-xl border border-dashed border-gray-200 bg-white/60 p-4 flex flex-col items-center gap-2 text-center">
+            <MapPin size={20} className="text-gray-300" />
+            <p className="text-xs text-gray-400 font-medium">Map navigation</p>
+          </div>
         </div>
       </section>
     </div>

--- a/src/app/technician/report-actions.ts
+++ b/src/app/technician/report-actions.ts
@@ -1,0 +1,110 @@
+'use server';
+
+import { db } from '@/db';
+import { technicianReports } from '@/db/schema/reports';
+import { quotations } from '@/db/schema/quotations';
+import { and, desc, eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function getMyReports() {
+  const session = await requireRole(['technician']);
+  return db
+    .select()
+    .from(technicianReports)
+    .where(eq(technicianReports.technicianId, session.user.id))
+    .orderBy(desc(technicianReports.createdAt));
+}
+
+export async function createReport(formData: FormData) {
+  const session = await requireRole(['technician']);
+
+  const title = (formData.get('title') as string)?.trim();
+  const content = (formData.get('content') as string)?.trim();
+  const undoneItems = (formData.get('undoneItems') as string)?.trim() || null;
+  const jobIdRaw = (formData.get('jobId') as string)?.trim() || null;
+
+  if (!title) throw new Error('Title is required');
+  if (!content) throw new Error('Content is required');
+
+  let jobId: string | null = null;
+  if (jobIdRaw) {
+    if (!UUID_RE.test(jobIdRaw)) throw new Error('Invalid job id');
+    // Verify the job is assigned to this technician.
+    const job = await db.query.quotations.findFirst({
+      where: and(eq(quotations.id, jobIdRaw), eq(quotations.assignedTo, session.user.id)),
+      columns: { id: true },
+    });
+    if (!job) throw new Error('Job not found or not assigned to you');
+    jobId = jobIdRaw;
+  }
+
+  await db.insert(technicianReports).values({
+    technicianId: session.user.id,
+    jobId,
+    title,
+    content,
+    undoneItems,
+    status: 'draft',
+  });
+
+  revalidatePath('/technician/reports');
+}
+
+export async function updateReport(formData: FormData) {
+  const session = await requireRole(['technician']);
+
+  const reportId = (formData.get('reportId') as string)?.trim();
+  const title = (formData.get('title') as string)?.trim();
+  const content = (formData.get('content') as string)?.trim();
+  const undoneItems = (formData.get('undoneItems') as string)?.trim() || null;
+
+  if (!reportId || !UUID_RE.test(reportId)) throw new Error('Invalid report id');
+  if (!title) throw new Error('Title is required');
+  if (!content) throw new Error('Content is required');
+
+  const updated = await db
+    .update(technicianReports)
+    .set({ title, content, undoneItems, updatedAt: new Date() })
+    .where(
+      and(
+        eq(technicianReports.id, reportId),
+        eq(technicianReports.technicianId, session.user.id),
+        eq(technicianReports.status, 'draft'),
+      ),
+    )
+    .returning({ id: technicianReports.id });
+
+  if (updated.length === 0) {
+    throw new Error('Report not found, not yours, or no longer a draft');
+  }
+
+  revalidatePath('/technician/reports');
+}
+
+export async function submitReport(formData: FormData) {
+  const session = await requireRole(['technician']);
+
+  const reportId = (formData.get('reportId') as string)?.trim();
+  if (!reportId || !UUID_RE.test(reportId)) throw new Error('Invalid report id');
+
+  const updated = await db
+    .update(technicianReports)
+    .set({ status: 'submitted', submittedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(
+        eq(technicianReports.id, reportId),
+        eq(technicianReports.technicianId, session.user.id),
+        eq(technicianReports.status, 'draft'),
+      ),
+    )
+    .returning({ id: technicianReports.id });
+
+  if (updated.length === 0) {
+    throw new Error('Report not found, not yours, or already submitted');
+  }
+
+  revalidatePath('/technician/reports');
+}

--- a/src/app/technician/reports/page.tsx
+++ b/src/app/technician/reports/page.tsx
@@ -1,0 +1,194 @@
+import Link from 'next/link';
+import { ArrowLeft, FileText, Plus } from 'lucide-react';
+import { getMyReports, createReport, updateReport, submitReport } from '../report-actions';
+import { getMyJobs } from '../actions';
+import { SubmitButton } from '@/components/dashboard/SubmitButton';
+
+const STATUS_COLORS: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-600',
+  submitted: 'bg-blue-100 text-blue-700',
+  reviewed: 'bg-green-100 text-green-700',
+};
+
+export default async function TechnicianReportsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ edit?: string }>;
+}) {
+  const params = await searchParams;
+  const editId = params.edit ?? null;
+
+  const [reports, myJobs] = await Promise.all([getMyReports(), getMyJobs()]);
+
+  const editReport = editId ? reports.find((r) => r.id === editId && r.status === 'draft') : null;
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/technician"
+        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-[#00477A] transition-colors"
+      >
+        <ArrowLeft size={16} /> Back to tasks
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-gray-900">My Reports</h2>
+        <span className="inline-flex items-center justify-center h-7 min-w-7 px-2 rounded-full bg-[#009FCE] text-white text-sm font-bold">
+          {reports.length}
+        </span>
+      </div>
+
+      {/* New / Edit report form */}
+      <section className="bg-white rounded-2xl border shadow-sm p-5">
+        <h3 className="font-semibold text-gray-900 mb-4">
+          {editReport ? 'Edit Report' : 'New Report'}
+        </h3>
+        <form action={editReport ? updateReport : createReport} className="space-y-4">
+          {editReport && (
+            <input type="hidden" name="reportId" value={editReport.id} />
+          )}
+
+          {/* Title */}
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1" htmlFor="rpt-title">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="rpt-title"
+              name="title"
+              required
+              maxLength={150}
+              defaultValue={editReport?.title ?? ''}
+              placeholder="Brief summary of the work"
+              className="w-full px-3 py-2.5 border rounded-xl text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]"
+            />
+          </div>
+
+          {/* Job (optional) */}
+          {!editReport && (
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1" htmlFor="rpt-job">
+                Related job (optional)
+              </label>
+              <select
+                id="rpt-job"
+                name="jobId"
+                className="w-full px-3 py-2.5 border rounded-xl text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]"
+              >
+                <option value="">— none —</option>
+                {myJobs.map((j) => (
+                  <option key={j.id} value={j.id}>
+                    {j.quotationNumber} — {j.customerName}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Work done */}
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1" htmlFor="rpt-content">
+              Work done <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="rpt-content"
+              name="content"
+              required
+              rows={5}
+              defaultValue={editReport?.content ?? ''}
+              placeholder="Describe what was completed…"
+              className="w-full px-3 py-2.5 border rounded-xl text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]"
+            />
+          </div>
+
+          {/* What remains */}
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1" htmlFor="rpt-undone">
+              What still needs to be done (optional)
+            </label>
+            <textarea
+              id="rpt-undone"
+              name="undoneItems"
+              rows={3}
+              defaultValue={editReport?.undoneItems ?? ''}
+              placeholder="Any remaining items or follow-up tasks…"
+              className="w-full px-3 py-2.5 border rounded-xl text-sm focus:ring-2 focus:ring-[#009FCE] focus:border-[#009FCE]"
+            />
+          </div>
+
+          <SubmitButton
+            label={editReport ? 'Save Changes' : 'Save Draft'}
+            pendingLabel="Saving…"
+            className="w-full h-12 rounded-xl bg-[#00477A] text-white font-semibold text-sm hover:bg-[#002B4A] transition-colors focus:outline-none focus:ring-2 focus:ring-[#009FCE] focus:ring-offset-2 disabled:opacity-60"
+          />
+        </form>
+      </section>
+
+      {/* Report list */}
+      {reports.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white p-10 text-center">
+          <FileText size={32} className="mx-auto text-gray-300 mb-3" />
+          <p className="font-medium text-gray-500">No reports yet</p>
+          <p className="text-sm text-gray-400 mt-1">Submit your first report using the form above.</p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {reports.map((r) => {
+            const statusColor = STATUS_COLORS[r.status] ?? 'bg-gray-100 text-gray-600';
+            return (
+              <li key={r.id} className="bg-white rounded-2xl border shadow-sm p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="font-semibold text-gray-900 leading-tight">{r.title}</p>
+                  <span className={`shrink-0 inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${statusColor}`}>
+                    {r.status}
+                  </span>
+                </div>
+
+                <p className="text-sm text-gray-600 line-clamp-3">{r.content}</p>
+
+                {r.undoneItems && (
+                  <div className="rounded-lg bg-amber-50 border border-amber-100 px-3 py-2">
+                    <p className="text-xs font-medium text-amber-700 mb-0.5">Still to do</p>
+                    <p className="text-xs text-amber-600 line-clamp-2">{r.undoneItems}</p>
+                  </div>
+                )}
+
+                {r.status === 'reviewed' && r.reviewNote && (
+                  <div className="rounded-lg bg-green-50 border border-green-100 px-3 py-2">
+                    <p className="text-xs font-medium text-green-700 mb-0.5">Manager note</p>
+                    <p className="text-xs text-green-700">{r.reviewNote}</p>
+                  </div>
+                )}
+
+                <p className="text-xs text-gray-400">
+                  {r.createdAt ? new Date(r.createdAt).toLocaleDateString('en-UG', { dateStyle: 'medium' }) : ''}
+                  {r.submittedAt ? ` · Submitted ${new Date(r.submittedAt).toLocaleDateString('en-UG', { dateStyle: 'medium' })}` : ''}
+                </p>
+
+                {r.status === 'draft' && (
+                  <div className="flex gap-2">
+                    <Link
+                      href={`/technician/reports?edit=${r.id}`}
+                      className="flex-1 h-10 inline-flex items-center justify-center rounded-xl border text-sm font-medium text-gray-700 hover:bg-slate-50 transition-colors"
+                    >
+                      Edit
+                    </Link>
+                    <form action={submitReport} className="flex-1">
+                      <input type="hidden" name="reportId" value={r.id} />
+                      <SubmitButton
+                        label="Submit"
+                        pendingLabel="Submitting…"
+                        className="w-full h-10 rounded-xl bg-[#009FCE] text-white font-semibold text-sm hover:bg-[#007baa] transition-colors focus:outline-none focus:ring-2 focus:ring-[#009FCE] focus:ring-offset-2 disabled:opacity-60"
+                      />
+                    </form>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/DirectorNav.tsx
+++ b/src/components/dashboard/DirectorNav.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, CheckSquare, BarChart2 } from 'lucide-react';
+import { LayoutDashboard, CheckSquare, BarChart2, FileText } from 'lucide-react';
 
 const ITEMS = [
   { href: '/director', label: 'Overview', icon: LayoutDashboard, exact: true },
   { href: '/director/approvals', label: 'Approvals', icon: CheckSquare, exact: false },
+  { href: '/director/quotations', label: 'Quotations', icon: FileText, exact: false },
   { href: '/director/reports', label: 'Reports', icon: BarChart2, exact: false },
 ];
 

--- a/src/components/dashboard/ManagerNav.tsx
+++ b/src/components/dashboard/ManagerNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Contact, ClipboardList, Users, MessagesSquare } from 'lucide-react';
+import { LayoutDashboard, Contact, ClipboardList, Users, MessagesSquare, FileText } from 'lucide-react';
 
 const ITEMS = [
   { href: '/manager', label: 'Overview', icon: LayoutDashboard, exact: true },
@@ -10,6 +10,7 @@ const ITEMS = [
   { href: '/manager/jobs', label: 'Jobs', icon: ClipboardList, exact: false },
   { href: '/manager/team', label: 'Team', icon: Users, exact: false },
   { href: '/manager/messages', label: 'Messages', icon: MessagesSquare, exact: false },
+  { href: '/manager/reports', label: 'Reports', icon: FileText, exact: false },
 ];
 
 export function ManagerNav() {

--- a/src/components/dashboard/SalesNav.tsx
+++ b/src/components/dashboard/SalesNav.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Users } from 'lucide-react';
+import { LayoutDashboard, Users, Briefcase } from 'lucide-react';
 
 const ITEMS = [
   { href: '/sales', label: 'Overview', icon: LayoutDashboard, exact: true },
   { href: '/sales/leads', label: 'Leads', icon: Users, exact: false },
+  { href: '/sales/jobs', label: 'Jobs', icon: Briefcase, exact: false },
 ];
 
 export function SalesNav() {

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -8,3 +8,4 @@ export * from './orders';
 export * from './quotations';
 export * from './payments';
 export * from './messages';
+export * from './reports';

--- a/src/db/schema/reports.ts
+++ b/src/db/schema/reports.ts
@@ -1,0 +1,37 @@
+import { pgTable, uuid, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { users } from './auth';
+import { quotations } from './quotations';
+
+export const technicianReports = pgTable('technician_reports', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  technicianId: uuid('technician_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  jobId: uuid('job_id').references(() => quotations.id, { onDelete: 'set null' }),
+  title: varchar('title', { length: 150 }).notNull(),
+  content: text('content').notNull(),
+  undoneItems: text('undone_items'),
+  status: varchar('status', { length: 20 }).notNull().default('draft'), // draft | submitted | reviewed
+  submittedAt: timestamp('submitted_at', { withTimezone: true }),
+  reviewedBy: uuid('reviewed_by').references(() => users.id, { onDelete: 'set null' }),
+  reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+  reviewNote: text('review_note'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const technicianReportsRelations = relations(technicianReports, ({ one }) => ({
+  technician: one(users, {
+    fields: [technicianReports.technicianId],
+    references: [users.id],
+    relationName: 'reportTechnician',
+  }),
+  job: one(quotations, {
+    fields: [technicianReports.jobId],
+    references: [quotations.id],
+  }),
+  reviewer: one(users, {
+    fields: [technicianReports.reviewedBy],
+    references: [users.id],
+    relationName: 'reportReviewer',
+  }),
+}));

--- a/src/lib/work-actions.ts
+++ b/src/lib/work-actions.ts
@@ -7,7 +7,7 @@ import { messages } from '@/db/schema/messages';
 import { and, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
-import { scopedCustomerIds, JOB_STATUSES, type JobStatus } from '@/lib/work';
+import { scopedCustomerIds, getActiveTechnicians, JOB_STATUSES, type JobStatus } from '@/lib/work';
 
 const WORK_ROLES = ['manager', 'director', 'sales_manager', 'super_admin'];
 
@@ -106,8 +106,12 @@ export async function sendStaffMessage(formData: FormData) {
   if (!content) return;
 
   const scope = await scopedCustomerIds(session);
-  if (scope !== null && !scope.includes(userId)) {
-    throw new Error('Forbidden: recipient outside your client scope');
+  if (scope !== null) {
+    const technicianIds = (await getActiveTechnicians()).map((t) => t.id);
+    const effectiveScope = [...new Set([...scope, ...technicianIds])];
+    if (!effectiveScope.includes(userId)) {
+      throw new Error('Forbidden: recipient outside your client scope');
+    }
   }
 
   await db.insert(messages).values({

--- a/src/lib/work-actions.ts
+++ b/src/lib/work-actions.ts
@@ -9,7 +9,7 @@ import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/auth';
 import { scopedCustomerIds, JOB_STATUSES, type JobStatus } from '@/lib/work';
 
-const WORK_ROLES = ['manager', 'director', 'super_admin'];
+const WORK_ROLES = ['manager', 'director', 'sales_manager', 'super_admin'];
 
 function revalidate(formData: FormData) {
   const path = (formData.get('_path') as string) || '/manager';

--- a/src/lib/work.ts
+++ b/src/lib/work.ts
@@ -29,7 +29,7 @@ function roleOf(session: Session): Role {
 // clients). super_admin returns null = full access (no scope filter).
 export async function scopedCustomerIds(session: Session): Promise<string[] | null> {
   const role = roleOf(session);
-  if (role === 'super_admin' || role === 'director') return null;
+  if (role === 'super_admin' || role === 'director' || role === 'sales_manager') return null;
 
   const rows = await db
     .select({ userId: clients.userId })


### PR DESCRIPTION
## What this delivers (owner requests, all four)

### 1. Customers: custom service type + location on requests
`/portal/dashboard` → Schedule → Request New Service now has an **"Other (describe below)"** option with a required free-text field (capped 100 chars), plus an optional **Location / Address** written to `quotations.location`. Submitting still creates a real quotation (status `pending`) that flows into the staff pipeline — this is how clients "create quotations" from their dashboard.

### 2. Duty assignment: director, manager, sales manager
- `WORK_ROLES` → `['manager','director','sales_manager','super_admin']` — all job mutations (assign technician, set status, verify) now open to all three management roles.
- New **`/sales/jobs`** page (Jobs tab in Sales nav) reusing the JobsBoard so the sales manager can assign technicians directly; sales manager granted full job scope.

### 3. Director: full quotation lifecycle
New **`/director/quotations`** page (Quotations tab): every quotation with status-aware action buttons, inline edit (`?edit=`), and a New Quotation form. Transition map enforced server-side in a transaction with an audit-log row per change:
- `pending|reviewed` → approve / reject / **hold** / cancel
- `on_hold` → approve / reject / reopen / cancel
- `approved` → hold / cancel; `rejected` → reopen
- `assigned|in_progress` → cancel (kill a live job)
- `completed|verified|converted` → terminal, untouchable
Sales pipeline gains On Hold + Cancelled stages so held quotations stay visible.

### 4. Technician reports + clarification messaging
- New `technician_reports` table (migration `drizzle/manual/0001_technician_reports.sql` — **already applied to the database**).
- Technicians (`/technician/reports`): create, edit (while draft), view, and **submit** reports — title, body, job link, and an explicit **"undone items"** section for stating what's incomplete. Status flow tracked: `draft → submitted → reviewed`.
- Managers + Director (`/manager/reports`, Reports tab): see all submitted reports with technician/job context and **Mark Reviewed** with an optional review note (reviewer + timestamp recorded).
- Technicians (`/technician/messages`): ask for clarification on assigned tasks — threads appear in the manager/admin Messages panels (scoped managers now see technician threads too, and can reply).

## Security
- Every new server action `requireRole`-guarded; technician report/message actions additionally enforce ownership (`technicianId = session.user.id`) in the WHERE clause.
- Director quotation mutations: UUID validation, status allow-list, `db.transaction` + audit log, `.returning()` zero-row guards.
- Drafts are private — managers/director only ever see `submitted|reviewed` reports.

## Verification
`npm run build` clean (45 routes incl. `/director/quotations`, `/sales/jobs`, `/manager/reports`, `/technician/reports`, `/technician/messages`), `npx tsc --noEmit` clean, role guards grep-verified.